### PR TITLE
Update Home info view

### DIFF
--- a/frontend/src/pages/Home.vue
+++ b/frontend/src/pages/Home.vue
@@ -3,14 +3,12 @@
     <h2>欢迎来到 DTS</h2>
     <div v-if="gameInfo" class="game-info">
       <p>游戏版本：{{ gameInfo.version }}</p>
-      <p>当前时刻：{{ formatTime(gameInfo.now) }}</p>
-      <p>游戏情报：第 {{ gameInfo.gamenum }} 回游戏 {{ gameInfo.active ? '开放激活' : '关闭激活' }}</p>
-      <p>本局已进行时间：{{ gameInfo.runtime }}</p>
-      <p>上局结果：{{ gameInfo.last_result }}</p>
-      <p>禁区数据：{{ gameInfo.area }}</p>
-      <p>激活人数：{{ gameInfo.validnum }}</p>
-      <p>生存人数：{{ gameInfo.alivenum }}</p>
-      <p>死亡总数：{{ gameInfo.deathnum }}</p>
+      <p>当前时刻：{{ formatTime(Date.now()) }}</p>
+      <p>状态：{{ gameStatus }}</p>
+      <p>已运行：{{ runtime }}</p>
+      <p>禁区数：{{ gameInfo.areaNum }}</p>
+      <p>存活玩家：{{ gameInfo.survivorCount }}</p>
+      <p>死亡总数：{{ gameInfo.deathCount }}</p>
       <el-button size="small" type="primary" @click="manualStart">手动开始游戏</el-button>
       <el-button size="small" type="danger" @click="manualStop" style="margin-left: 8px">手动关闭游戏</el-button>
     </div>
@@ -74,10 +72,24 @@ function formatTime(t) {
   return new Date(t).toLocaleString()
 }
 
+const gameStatus = computed(() => {
+  if (!gameInfo.value) return '未知'
+  return gameInfo.value.gamestate === 'active' ? '进行中' : '未开始'
+})
+
+const runtime = computed(() => {
+  if (!gameInfo.value?.startTime) return 'N/A'
+  const diff = Date.now() - new Date(gameInfo.value.startTime).getTime()
+  const h = Math.floor(diff / 3600000)
+  const m = Math.floor((diff % 3600000) / 60000)
+  const s = Math.floor((diff % 60000) / 1000)
+  return `${h}小时${m}分${s}秒`
+})
+
 async function fetchGameInfo() {
   try {
     const { data } = await getGameInfo()
-    gameInfo.value = data
+    gameInfo.value = data || {}
   } catch (e) {
     console.error(e)
   }


### PR DESCRIPTION
## Summary
- show game status fields returned by the backend
- compute status and running time from `gamestate`/`startTime`
- guard against missing data in `fetchGameInfo`

## Testing
- `npm test` within `backend` *(fails: no test specified)*
- `npm test` within `frontend` *(fails: missing script)*

------
https://chatgpt.com/codex/tasks/task_e_6870a8545a2883229cfd00e0216e8ec5