### PR TITLE
Improve admin interface

### DIFF
--- a/backend/src/routes/admin.js
+++ b/backend/src/routes/admin.js
@@ -24,6 +24,13 @@ function getModel(name) {
   return models[name];
 }
 
+router.get('/:collection/fields', (req, res) => {
+  const Model = getModel(req.params.collection);
+  if (!Model) return res.status(404).json({ msg: '集合不存在' });
+  const fields = Object.keys(Model.schema.paths).filter(k => k !== '__v');
+  res.json(fields);
+});
+
 router.get('/:collection', async (req, res) => {
   const Model = getModel(req.params.collection);
   if (!Model) return res.status(404).json({ msg: '集合不存在' });

--- a/frontend/src/api/index.js
+++ b/frontend/src/api/index.js
@@ -32,5 +32,6 @@ export const adminList = col => api.get(`/admin/${col}`)
 export const adminCreate = (col, data) => api.post(`/admin/${col}`, data)
 export const adminUpdate = (col, id, data) => api.put(`/admin/${col}/${id}`, data)
 export const adminDelete = (col, id) => api.delete(`/admin/${col}/${id}`)
+export const adminFields = col => api.get(`/admin/${col}/fields`)
 
 export default api

--- a/frontend/src/pages/Admin.vue
+++ b/frontend/src/pages/Admin.vue
@@ -7,6 +7,7 @@
     <el-button type="primary" size="small" @click="openCreate" style="margin-left:10px">新建</el-button>
     <el-table :data="items" style="margin-top: 20px" row-key="_id">
       <el-table-column prop="_id" label="ID" width="230" />
+      <el-table-column v-for="f in displayFields" :key="f" :prop="f" :label="f" />
       <el-table-column label="数据">
         <template #default="{ row }">
           <pre>{{ json(row) }}</pre>
@@ -35,12 +36,13 @@
 </template>
 
 <script setup>
-import { ref, watch } from 'vue'
+import { ref, watch, computed } from 'vue'
 import {
   adminList,
   adminCreate,
   adminUpdate,
-  adminDelete
+  adminDelete,
+  adminFields
 } from '../api'
 
 const collections = [
@@ -62,8 +64,15 @@ const items = ref([])
 const dialogVisible = ref(false)
 const editData = ref('')
 const editId = ref('')
+const fields = ref([])
 
-watch(collection, fetchItems)
+const displayFields = computed(() => fields.value.slice(0, 5))
+watch(collection, () => {
+  fetchItems()
+  fetchFields()
+})
+
+if (collections.length) collection.value = collections[0].value
 
 function json(obj) {
   return JSON.stringify(obj, null, 2)
@@ -76,6 +85,17 @@ async function fetchItems() {
     items.value = data
   } catch (e) {
     alert(e.response?.data?.msg || '加载失败')
+  }
+}
+
+async function fetchFields() {
+  if (!collection.value) return
+  try {
+    const { data } = await adminFields(collection.value)
+    fields.value = data
+  } catch (e) {
+    console.error(e)
+    fields.value = []
   }
 }
 


### PR DESCRIPTION
## Summary
- add field list endpoint for admin collections
- expose `adminFields` API on frontend
- show common fields in Admin page table

## Testing
- `npm test` in backend (fails: no test specified)
- `npm test` in frontend (fails: missing script)


------
https://chatgpt.com/codex/tasks/task_e_6870c7351d0c8322aa47b016525a2c08