### PR TITLE
Fix duplicate API export

### DIFF
--- a/frontend/src/api/index.js
+++ b/frontend/src/api/index.js
@@ -38,7 +38,6 @@ export const rest = pid => api.post('/game/rest', { pid })
 export const pickItem = (pid, itemId) => api.post('/game/pick', { pid, itemId })
 export const useItem = (pid, index) => api.post('/game/use', { pid, index })
 export const equipItem = (pid, index) => api.post('/game/equip', { pid, index })
-export const pickItem = (pid, iid) => api.post('/game/pick', { pid, iid })
 
 export const adminList = col => api.get(`/admin/${col}`)
 export const adminCreate = (col, data) => api.post(`/admin/${col}`, data)


### PR DESCRIPTION
## Summary
- remove duplicate export for `pickItem` in frontend API

## Testing
- `npm run build` in `frontend`
- `npm test` in `backend` *(fails: no test specified)*

------
https://chatgpt.com/codex/tasks/task_e_6874b1f3193483228168bdddaadb5073