### PR TITLE
Update stamina display and balance

### DIFF
--- a/backend/src/controllers/playerController.js
+++ b/backend/src/controllers/playerController.js
@@ -56,8 +56,8 @@ exports.enter = async (req, res) => {
         pls: 0,
         hp: 100,
         mhp: 100,
-        sp: 100,
-        msp: 100
+        sp: 200,
+        msp: 200
       });
       user.lastgame = gid;
       user.lastpid = pid;
@@ -83,7 +83,7 @@ exports.move = async (req, res) => {
 
     applyRest(player);
 
-    const spCost = 15;
+    const spCost = 20 + Math.floor(Math.random() * 21) - 10;
     if (player.sp < spCost) {
       return res.status(400).json({ msg: '体力不足，不能移动' });
     }
@@ -111,7 +111,7 @@ exports.search = async (req, res) => {
   if (!player) return res.status(404).json({ msg: '玩家不存在' });
 
   applyRest(player);
-  const spCost = 15;
+  const spCost = 10 + Math.floor(Math.random() * 11) - 5;
   if (player.sp < spCost) {
     return res.status(400).json({ msg: '体力不足，不能探索' });
   }

--- a/frontend/src/pages/Map.vue
+++ b/frontend/src/pages/Map.vue
@@ -49,12 +49,12 @@
             <el-col :span="24" class="status-block">
               <span class="label">生命：</span>
               <el-progress :percentage="hpPercent" :stroke-width="18" status="success" />
-              <p class="percent-label">{{ hpPercent }}%</p>
+              <p class="percent-label">{{ hpLabel }}</p>
             </el-col>
             <el-col :span="24" class="status-block">
               <span class="label">体力：</span>
               <el-progress :percentage="spPercent" :stroke-width="18" status="warning" />
-              <p class="percent-label">{{ spPercent }}%</p>
+              <p class="percent-label">{{ spLabel }}</p>
             </el-col>
           </el-row>
         </el-card>
@@ -161,6 +161,12 @@ const hpPercent = computed(() =>
 )
 const spPercent = computed(() =>
   info.value ? Math.round((info.value.sp / info.value.msp) * 100) : 0
+)
+const hpLabel = computed(() =>
+  info.value ? `${info.value.hp}/${info.value.mhp}` : '0/0'
+)
+const spLabel = computed(() =>
+  info.value ? `${info.value.sp}/${info.value.msp}` : '0/0'
 )
 const injuries = computed(() => {
   if (!info.value || !info.value.inf) return '无'

--- a/frontend/src/pages/Status.vue
+++ b/frontend/src/pages/Status.vue
@@ -4,10 +4,10 @@
     <el-descriptions v-if="info" border :column="2" style="margin-top:10px">
       <el-descriptions-item label="位置">{{ place }}</el-descriptions-item>
       <el-descriptions-item label="生命">
-        <el-progress :percentage="hpPercent" :text-inside="true" />
+        <el-progress :percentage="hpPercent" :format="hpFormat" :text-inside="true" />
       </el-descriptions-item>
       <el-descriptions-item label="体力">
-        <el-progress :percentage="spPercent" :text-inside="true" />
+        <el-progress :percentage="spPercent" :format="spFormat" :text-inside="true" />
       </el-descriptions-item>
       <el-descriptions-item label="等级">{{ info.lvl }}</el-descriptions-item>
       <el-descriptions-item label="经验">{{ info.exp }}</el-descriptions-item>
@@ -33,6 +33,8 @@ const hpPercent = computed(() =>
 const spPercent = computed(() =>
   info.value ? Math.round((info.value.sp / info.value.msp) * 100) : 0
 )
+const hpFormat = () => info.value ? `${info.value.hp}/${info.value.mhp}` : '0/0'
+const spFormat = () => info.value ? `${info.value.sp}/${info.value.msp}` : '0/0'
 const profs = computed(() => {
   if (!info.value) return []
   return [


### PR DESCRIPTION
## Summary
- show HP and SP as `current/max`
- adjust default stamina to 200
- tune move/search stamina costs with randomness

## Testing
- `npm --prefix frontend run build`


------
https://chatgpt.com/codex/tasks/task_e_6875d9aa626483228c394a60f600e299