### PR TITLE
Implement atomic item pickup with optimistic locking

### DIFF
--- a/backend/src/controllers/playerController.js
+++ b/backend/src/controllers/playerController.js
@@ -1,8 +1,10 @@
+const mongoose = require('mongoose');
 const Player = require('../models/Player');
 const MapItem = require('../models/MapItem');
 const MapTrap = require('../models/MapTrap');
 const GameInfo = require('../models/GameInfo');
 const MapArea = require('../models/MapArea');
+const { dropMapItem } = require('../utils/item');
 
 const START_THRESHOLD = 20;
 
@@ -32,17 +34,6 @@ function reduceItem(player, idx) {
   }
 }
 
-async function dropMapItem(pls, name, kind, effect, uses, skill) {
-  if (!name) return;
-  await MapItem.create({
-    itm: name,
-    itmk: kind,
-    itme: effect,
-    itms: uses,
-    itmsk: skill,
-    pls
-  });
-}
 
 exports.enter = async (req, res) => {
   try {
@@ -216,29 +207,47 @@ exports.rest = async (req, res) => {
 };
 
 exports.pickItem = async (req, res) => {
+  const session = await mongoose.startSession();
+  session.startTransaction();
   try {
     const { pid, itemId } = req.body;
-    const player = await Player.findOne({ pid, uid: req.user._id });
-    if (!player) return res.status(404).json({ msg: '玩家不存在' });
+    const player = await Player.findOne({ pid, uid: req.user._id }).session(session);
+    if (!player) {
+      await session.abortTransaction();
+      session.endSession();
+      return res.status(404).json({ msg: '玩家不存在' });
+    }
 
-    const item = await MapItem.findOne({ _id: itemId, pls: player.pls });
-    if (!item) return res.status(400).json({ msg: '物品不存在' });
+    const item = await MapItem.findOne({ _id: itemId }).session(session);
+    if (!item || item.pls !== player.pls) {
+      await session.abortTransaction();
+      session.endSession();
+      return res.status(400).json({ msg: '物品不存在' });
+    }
 
     let slot = -1;
     for (let i = 0; i < 5; i++) {
       if (!player[`itm${i}`]) { slot = i; break; }
     }
-    if (slot === -1) return res.status(400).json({ msg: '物品栏已满' });
+    if (slot === -1) {
+      await session.abortTransaction();
+      session.endSession();
+      return res.status(400).json({ msg: '物品栏已满' });
+    }
 
     player[`itm${slot}`] = item.itm;
     player[`itmk${slot}`] = item.itmk;
     player[`itme${slot}`] = item.itme;
     player[`itms${slot}`] = item.itms;
     player[`itmsk${slot}`] = item.itmsk;
-    await MapItem.deleteOne({ _id: item._id });
-    await player.save();
+    await MapItem.deleteOne({ _id: item._id }).session(session);
+    await player.save({ session });
+    await session.commitTransaction();
+    session.endSession();
     res.json({ msg: `获得了${item.itm}`, player });
   } catch (err) {
+    await session.abortTransaction();
+    session.endSession();
     console.error(err);
     res.status(500).json({ msg: '拾取失败' });
   }
@@ -461,14 +470,28 @@ exports.unequip = async (req, res) => {
 };
 
 exports.pickReplace = async (req, res) => {
+  const session = await mongoose.startSession();
+  session.startTransaction();
   try {
     const { pid, itemId, index } = req.body;
-    const player = await Player.findOne({ pid, uid: req.user._id });
-    if (!player) return res.status(404).json({ msg: '玩家不存在' });
-    if (index < 0 || index >= 5) return res.status(400).json({ msg: '物品编号错误' });
+    const player = await Player.findOne({ pid, uid: req.user._id }).session(session);
+    if (!player) {
+      await session.abortTransaction();
+      session.endSession();
+      return res.status(404).json({ msg: '玩家不存在' });
+    }
+    if (index < 0 || index >= 5) {
+      await session.abortTransaction();
+      session.endSession();
+      return res.status(400).json({ msg: '物品编号错误' });
+    }
 
-    const item = await MapItem.findOne({ _id: itemId, pls: player.pls });
-    if (!item) return res.status(400).json({ msg: '物品不存在' });
+    const item = await MapItem.findOne({ _id: itemId }).session(session);
+    if (!item || item.pls !== player.pls) {
+      await session.abortTransaction();
+      session.endSession();
+      return res.status(400).json({ msg: '物品不存在' });
+    }
 
     const dropName = player[`itm${index}`];
     const dropKind = player[`itmk${index}`];
@@ -483,7 +506,8 @@ exports.pickReplace = async (req, res) => {
         dropKind,
         dropEffect,
         dropUses,
-        dropSkill
+        dropSkill,
+        session
       );
     }
 
@@ -493,10 +517,14 @@ exports.pickReplace = async (req, res) => {
     player[`itms${index}`] = item.itms;
     player[`itmsk${index}`] = item.itmsk;
 
-    await MapItem.deleteOne({ _id: item._id });
-    await player.save();
-    res.json({ msg: `获得了${item.itm}`, player });
+    await MapItem.deleteOne({ _id: item._id }).session(session);
+    await player.save({ session });
+    await session.commitTransaction();
+    session.endSession();
+    res.json({ msg: `获得了${item.itm}`, player, dropName });
   } catch (err) {
+    await session.abortTransaction();
+    session.endSession();
     console.error(err);
     res.status(500).json({ msg: '拾取失败' });
   }

--- a/backend/src/utils/item.js
+++ b/backend/src/utils/item.js
@@ -1,0 +1,15 @@
+const MapItem = require('../models/MapItem');
+
+async function dropMapItem(pls, name, kind, effect, uses, skill, session) {
+  if (!name) return;
+  const data = { itm: name, itmk: kind, itme: effect, itms: uses, itmsk: skill, pls };
+  if (session) {
+    await MapItem.create([data], { session });
+  } else {
+    await MapItem.create(data);
+  }
+}
+
+module.exports = {
+  dropMapItem
+};


### PR DESCRIPTION
## Summary
- modularize drop logic into `utils/item.js`
- add optimistic lock and MongoDB session when picking or replacing items
- return `dropName` to help front-end display dropped item name

## Testing
- `npm run lint` *(fails: Missing script)*
- `npm test` *(fails: no test specified)*

------
https://chatgpt.com/codex/tasks/task_e_6875e25371b483229f692a2c5cdfb4c7