### PR TITLE
Implement map trap pool

### DIFF
--- a/backend/src/controllers/gameController.js
+++ b/backend/src/controllers/gameController.js
@@ -3,6 +3,7 @@ const History = require('../models/History');
 const MapArea = require('../models/MapArea');
 const Player = require('../models/Player');
 const MapItem = require('../models/MapItem');
+const MapTrap = require('../models/MapTrap');
 const fs = require('fs');
 const path = require('path');
 
@@ -67,6 +68,18 @@ exports.startGame = async (req, res) => {
       }
     } catch (e) {
       console.error('初始化地图物品失败', e);
+    }
+
+    // 初始化地图陷阱
+    try {
+      const file = path.join(__dirname, '../../../data/maptraps.json');
+      const traps = JSON.parse(fs.readFileSync(file));
+      await MapTrap.deleteMany({});
+      if (traps && traps.length) {
+        await MapTrap.insertMany(traps);
+      }
+    } catch (e) {
+      console.error('初始化地图陷阱失败', e);
     }
 
     // 开局前清理旧玩家数据

--- a/backend/src/controllers/playerController.js
+++ b/backend/src/controllers/playerController.js
@@ -177,12 +177,19 @@ exports.search = async (req, res) => {
       return res.json({ log, player });
     }
 
-    const trap = await MapTrap.findOne({ pls: player.pls });
-    if (trap) {
-      await MapTrap.deleteOne({ _id: trap._id });
-      log += `你触发了陷阱【${trap.itm}】！<br>`;
-      await player.save();
-      return res.json({ log, player });
+    const area = await MapArea.findOne({ pid: player.pls });
+    const trapRate = (area && area.danger ? area.danger * 0.05 : 0);
+    if (Math.random() < trapRate) {
+      const traps = await MapTrap.find({ pls: player.pls });
+      if (traps.length) {
+        const trap = traps[Math.floor(Math.random() * traps.length)];
+        await MapTrap.deleteOne({ _id: trap._id });
+        const dmg = trap.itme || 0;
+        player.hp = Math.max(player.hp - dmg, 0);
+        log += `你触发了陷阱【${trap.itm}】，受到了${dmg}点伤害！<br>`;
+        await player.save();
+        return res.json({ log, player });
+      }
     }
 
     const items = await MapItem.find({ pls: player.pls });

--- a/data/initData.js
+++ b/data/initData.js
@@ -23,6 +23,13 @@ if (mapareas.length) {
   db.mapareas.insertMany(mapareas);
 }
 
+// 导入 maptraps
+var maptraps = JSON.parse(cat('./maptraps.json'));
+if (maptraps.length) {
+  db.maptraps.remove({});
+  db.maptraps.insertMany(maptraps);
+}
+
 // 导入 mapitems
 var mapitems = JSON.parse(cat('./mapitems.json'));
 if (mapitems.length) {

--- a/data/maptraps.json
+++ b/data/maptraps.json
@@ -1,0 +1,3413 @@
+[
+  {
+    "tid": 1,
+    "itm": "【最终机枪防线】",
+    "itmk": "TO",
+    "itme": 400,
+    "itms": "1",
+    "itmsk": "1",
+    "pls": 0
+  },
+  {
+    "tid": 2,
+    "itm": "【最终机枪防线】",
+    "itmk": "TO",
+    "itme": 400,
+    "itms": "1",
+    "itmsk": "1",
+    "pls": 0
+  },
+  {
+    "tid": 3,
+    "itm": "【最终机枪防线】",
+    "itmk": "TO",
+    "itme": 400,
+    "itms": "1",
+    "itmsk": "1",
+    "pls": 0
+  },
+  {
+    "tid": 4,
+    "itm": "【最终机枪防线】",
+    "itmk": "TO",
+    "itme": 400,
+    "itms": "1",
+    "itmsk": "1",
+    "pls": 0
+  },
+  {
+    "tid": 5,
+    "itm": "【最终机枪防线】",
+    "itmk": "TO",
+    "itme": 400,
+    "itms": "1",
+    "itmsk": "1",
+    "pls": 0
+  },
+  {
+    "tid": 6,
+    "itm": "【最终机枪防线】",
+    "itmk": "TO",
+    "itme": 400,
+    "itms": "1",
+    "itmsk": "1",
+    "pls": 0
+  },
+  {
+    "tid": 7,
+    "itm": "【最终机枪防线】",
+    "itmk": "TO",
+    "itme": 400,
+    "itms": "1",
+    "itmsk": "1",
+    "pls": 0
+  },
+  {
+    "tid": 8,
+    "itm": "【最终机枪防线】",
+    "itmk": "TO",
+    "itme": 400,
+    "itms": "1",
+    "itmsk": "1",
+    "pls": 0
+  },
+  {
+    "tid": 9,
+    "itm": "【最终机枪防线】",
+    "itmk": "TO",
+    "itme": 400,
+    "itms": "1",
+    "itmsk": "1",
+    "pls": 0
+  },
+  {
+    "tid": 10,
+    "itm": "【最终机枪防线】",
+    "itmk": "TO",
+    "itme": 400,
+    "itms": "1",
+    "itmsk": "1",
+    "pls": 0
+  },
+  {
+    "tid": 11,
+    "itm": "【最终机枪防线】",
+    "itmk": "TO",
+    "itme": 400,
+    "itms": "1",
+    "itmsk": "1",
+    "pls": 0
+  },
+  {
+    "tid": 12,
+    "itm": "【最终机枪防线】",
+    "itmk": "TO",
+    "itme": 400,
+    "itms": "1",
+    "itmsk": "1",
+    "pls": 0
+  },
+  {
+    "tid": 13,
+    "itm": "【最终机枪防线】",
+    "itmk": "TO",
+    "itme": 400,
+    "itms": "1",
+    "itmsk": "1",
+    "pls": 0
+  },
+  {
+    "tid": 14,
+    "itm": "【最终机枪防线】",
+    "itmk": "TO",
+    "itme": 400,
+    "itms": "1",
+    "itmsk": "1",
+    "pls": 0
+  },
+  {
+    "tid": 15,
+    "itm": "【最终机枪防线】",
+    "itmk": "TO",
+    "itme": 400,
+    "itms": "1",
+    "itmsk": "1",
+    "pls": 0
+  },
+  {
+    "tid": 16,
+    "itm": "【最终机枪防线】",
+    "itmk": "TO",
+    "itme": 400,
+    "itms": "1",
+    "itmsk": "1",
+    "pls": 0
+  },
+  {
+    "tid": 17,
+    "itm": "【最终火炮防线】",
+    "itmk": "TO",
+    "itme": 500,
+    "itms": "1",
+    "itmsk": "1",
+    "pls": 0
+  },
+  {
+    "tid": 18,
+    "itm": "【最终火炮防线】",
+    "itmk": "TO",
+    "itme": 500,
+    "itms": "1",
+    "itmsk": "1",
+    "pls": 0
+  },
+  {
+    "tid": 19,
+    "itm": "【最终火炮防线】",
+    "itmk": "TO",
+    "itme": 500,
+    "itms": "1",
+    "itmsk": "1",
+    "pls": 0
+  },
+  {
+    "tid": 20,
+    "itm": "【最终火炮防线】",
+    "itmk": "TO",
+    "itme": 500,
+    "itms": "1",
+    "itmsk": "1",
+    "pls": 0
+  },
+  {
+    "tid": 21,
+    "itm": "【最终火炮防线】",
+    "itmk": "TO",
+    "itme": 500,
+    "itms": "1",
+    "itmsk": "1",
+    "pls": 0
+  },
+  {
+    "tid": 22,
+    "itm": "【最终火炮防线】",
+    "itmk": "TO",
+    "itme": 500,
+    "itms": "1",
+    "itmsk": "1",
+    "pls": 0
+  },
+  {
+    "tid": 23,
+    "itm": "【最终火炮防线】",
+    "itmk": "TO",
+    "itme": 500,
+    "itms": "1",
+    "itmsk": "1",
+    "pls": 0
+  },
+  {
+    "tid": 24,
+    "itm": "【最终火炮防线】",
+    "itmk": "TO",
+    "itme": 500,
+    "itms": "1",
+    "itmsk": "1",
+    "pls": 0
+  },
+  {
+    "tid": 25,
+    "itm": "【最终火炮防线】",
+    "itmk": "TO",
+    "itme": 500,
+    "itms": "1",
+    "itmsk": "1",
+    "pls": 0
+  },
+  {
+    "tid": 26,
+    "itm": "【最终火炮防线】",
+    "itmk": "TO",
+    "itme": 500,
+    "itms": "1",
+    "itmsk": "1",
+    "pls": 0
+  },
+  {
+    "tid": 27,
+    "itm": "【最终火炮防线】",
+    "itmk": "TO",
+    "itme": 500,
+    "itms": "1",
+    "itmsk": "1",
+    "pls": 0
+  },
+  {
+    "tid": 28,
+    "itm": "【最终火炮防线】",
+    "itmk": "TO",
+    "itme": 500,
+    "itms": "1",
+    "itmsk": "1",
+    "pls": 0
+  },
+  {
+    "tid": 29,
+    "itm": "【最终火炮防线】",
+    "itmk": "TO",
+    "itme": 500,
+    "itms": "1",
+    "itmsk": "1",
+    "pls": 0
+  },
+  {
+    "tid": 30,
+    "itm": "【最终火炮防线】",
+    "itmk": "TO",
+    "itme": 500,
+    "itms": "1",
+    "itmsk": "1",
+    "pls": 0
+  },
+  {
+    "tid": 31,
+    "itm": "【最终火炮防线】",
+    "itmk": "TO",
+    "itme": 500,
+    "itms": "1",
+    "itmsk": "1",
+    "pls": 0
+  },
+  {
+    "tid": 32,
+    "itm": "【最终火炮防线】",
+    "itmk": "TO",
+    "itme": 500,
+    "itms": "1",
+    "itmsk": "1",
+    "pls": 0
+  },
+  {
+    "tid": 33,
+    "itm": "【最终结界防线】",
+    "itmk": "TO",
+    "itme": 600,
+    "itms": "1",
+    "itmsk": "1",
+    "pls": 0
+  },
+  {
+    "tid": 34,
+    "itm": "【最终结界防线】",
+    "itmk": "TO",
+    "itme": 600,
+    "itms": "1",
+    "itmsk": "1",
+    "pls": 0
+  },
+  {
+    "tid": 35,
+    "itm": "【最终结界防线】",
+    "itmk": "TO",
+    "itme": 600,
+    "itms": "1",
+    "itmsk": "1",
+    "pls": 0
+  },
+  {
+    "tid": 36,
+    "itm": "【最终结界防线】",
+    "itmk": "TO",
+    "itme": 600,
+    "itms": "1",
+    "itmsk": "1",
+    "pls": 0
+  },
+  {
+    "tid": 37,
+    "itm": "【最终结界防线】",
+    "itmk": "TO",
+    "itme": 600,
+    "itms": "1",
+    "itmsk": "1",
+    "pls": 0
+  },
+  {
+    "tid": 38,
+    "itm": "【最终结界防线】",
+    "itmk": "TO",
+    "itme": 600,
+    "itms": "1",
+    "itmsk": "1",
+    "pls": 0
+  },
+  {
+    "tid": 39,
+    "itm": "【最终结界防线】",
+    "itmk": "TO",
+    "itme": 600,
+    "itms": "1",
+    "itmsk": "1",
+    "pls": 0
+  },
+  {
+    "tid": 40,
+    "itm": "【最终结界防线】",
+    "itmk": "TO",
+    "itme": 600,
+    "itms": "1",
+    "itmsk": "1",
+    "pls": 0
+  },
+  {
+    "tid": 41,
+    "itm": "【最终结界防线】",
+    "itmk": "TO",
+    "itme": 600,
+    "itms": "1",
+    "itmsk": "1",
+    "pls": 0
+  },
+  {
+    "tid": 42,
+    "itm": "【最终结界防线】",
+    "itmk": "TO",
+    "itme": 600,
+    "itms": "1",
+    "itmsk": "1",
+    "pls": 0
+  },
+  {
+    "tid": 43,
+    "itm": "【最终结界防线】",
+    "itmk": "TO",
+    "itme": 600,
+    "itms": "1",
+    "itmsk": "1",
+    "pls": 0
+  },
+  {
+    "tid": 44,
+    "itm": "【最终结界防线】",
+    "itmk": "TO",
+    "itme": 600,
+    "itms": "1",
+    "itmsk": "1",
+    "pls": 0
+  },
+  {
+    "tid": 45,
+    "itm": "【最终结界防线】",
+    "itmk": "TO",
+    "itme": 600,
+    "itms": "1",
+    "itmsk": "1",
+    "pls": 0
+  },
+  {
+    "tid": 46,
+    "itm": "【最终结界防线】",
+    "itmk": "TO",
+    "itme": 600,
+    "itms": "1",
+    "itmsk": "1",
+    "pls": 0
+  },
+  {
+    "tid": 47,
+    "itm": "【最终结界防线】",
+    "itmk": "TO",
+    "itme": 600,
+    "itms": "1",
+    "itmsk": "1",
+    "pls": 0
+  },
+  {
+    "tid": 48,
+    "itm": "【最终结界防线】",
+    "itmk": "TO",
+    "itme": 600,
+    "itms": "1",
+    "itmsk": "1",
+    "pls": 0
+  },
+  {
+    "tid": 49,
+    "itm": "【最终能量防线】",
+    "itmk": "TO",
+    "itme": 800,
+    "itms": "1",
+    "itmsk": "1",
+    "pls": 0
+  },
+  {
+    "tid": 50,
+    "itm": "【最终能量防线】",
+    "itmk": "TO",
+    "itme": 800,
+    "itms": "1",
+    "itmsk": "1",
+    "pls": 0
+  },
+  {
+    "tid": 51,
+    "itm": "【最终能量防线】",
+    "itmk": "TO",
+    "itme": 800,
+    "itms": "1",
+    "itmsk": "1",
+    "pls": 0
+  },
+  {
+    "tid": 52,
+    "itm": "【最终能量防线】",
+    "itmk": "TO",
+    "itme": 800,
+    "itms": "1",
+    "itmsk": "1",
+    "pls": 0
+  },
+  {
+    "tid": 53,
+    "itm": "【最终能量防线】",
+    "itmk": "TO",
+    "itme": 800,
+    "itms": "1",
+    "itmsk": "1",
+    "pls": 0
+  },
+  {
+    "tid": 54,
+    "itm": "【最终能量防线】",
+    "itmk": "TO",
+    "itme": 800,
+    "itms": "1",
+    "itmsk": "1",
+    "pls": 0
+  },
+  {
+    "tid": 55,
+    "itm": "【最终能量防线】",
+    "itmk": "TO",
+    "itme": 800,
+    "itms": "1",
+    "itmsk": "1",
+    "pls": 0
+  },
+  {
+    "tid": 56,
+    "itm": "【最终能量防线】",
+    "itmk": "TO",
+    "itme": 800,
+    "itms": "1",
+    "itmsk": "1",
+    "pls": 0
+  },
+  {
+    "tid": 57,
+    "itm": "【最终能量防线】",
+    "itmk": "TO",
+    "itme": 800,
+    "itms": "1",
+    "itmsk": "1",
+    "pls": 0
+  },
+  {
+    "tid": 58,
+    "itm": "【最终能量防线】",
+    "itmk": "TO",
+    "itme": 800,
+    "itms": "1",
+    "itmsk": "1",
+    "pls": 0
+  },
+  {
+    "tid": 59,
+    "itm": "【最终能量防线】",
+    "itmk": "TO",
+    "itme": 800,
+    "itms": "1",
+    "itmsk": "1",
+    "pls": 0
+  },
+  {
+    "tid": 60,
+    "itm": "【最终能量防线】",
+    "itmk": "TO",
+    "itme": 800,
+    "itms": "1",
+    "itmsk": "1",
+    "pls": 0
+  },
+  {
+    "tid": 61,
+    "itm": "【最终能量防线】",
+    "itmk": "TO",
+    "itme": 800,
+    "itms": "1",
+    "itmsk": "1",
+    "pls": 0
+  },
+  {
+    "tid": 62,
+    "itm": "【最终能量防线】",
+    "itmk": "TO",
+    "itme": 800,
+    "itms": "1",
+    "itmsk": "1",
+    "pls": 0
+  },
+  {
+    "tid": 63,
+    "itm": "【最终能量防线】",
+    "itmk": "TO",
+    "itme": 800,
+    "itms": "1",
+    "itmsk": "1",
+    "pls": 0
+  },
+  {
+    "tid": 64,
+    "itm": "【最终能量防线】",
+    "itmk": "TO",
+    "itme": 800,
+    "itms": "1",
+    "itmsk": "1",
+    "pls": 0
+  },
+  {
+    "tid": 65,
+    "itm": "【最终数据防线】",
+    "itmk": "TO",
+    "itme": 1000,
+    "itms": "1",
+    "itmsk": "1",
+    "pls": 0
+  },
+  {
+    "tid": 66,
+    "itm": "【最终数据防线】",
+    "itmk": "TO",
+    "itme": 1000,
+    "itms": "1",
+    "itmsk": "1",
+    "pls": 0
+  },
+  {
+    "tid": 67,
+    "itm": "【最终数据防线】",
+    "itmk": "TO",
+    "itme": 1000,
+    "itms": "1",
+    "itmsk": "1",
+    "pls": 0
+  },
+  {
+    "tid": 68,
+    "itm": "【最终数据防线】",
+    "itmk": "TO",
+    "itme": 1000,
+    "itms": "1",
+    "itmsk": "1",
+    "pls": 0
+  },
+  {
+    "tid": 69,
+    "itm": "【最终数据防线】",
+    "itmk": "TO",
+    "itme": 1000,
+    "itms": "1",
+    "itmsk": "1",
+    "pls": 0
+  },
+  {
+    "tid": 70,
+    "itm": "【最终数据防线】",
+    "itmk": "TO",
+    "itme": 1000,
+    "itms": "1",
+    "itmsk": "1",
+    "pls": 0
+  },
+  {
+    "tid": 71,
+    "itm": "【最终数据防线】",
+    "itmk": "TO",
+    "itme": 1000,
+    "itms": "1",
+    "itmsk": "1",
+    "pls": 0
+  },
+  {
+    "tid": 72,
+    "itm": "【最终数据防线】",
+    "itmk": "TO",
+    "itme": 1000,
+    "itms": "1",
+    "itmsk": "1",
+    "pls": 0
+  },
+  {
+    "tid": 73,
+    "itm": "【最终数据防线】",
+    "itmk": "TO",
+    "itme": 1000,
+    "itms": "1",
+    "itmsk": "1",
+    "pls": 0
+  },
+  {
+    "tid": 74,
+    "itm": "【最终数据防线】",
+    "itmk": "TO",
+    "itme": 1000,
+    "itms": "1",
+    "itmsk": "1",
+    "pls": 0
+  },
+  {
+    "tid": 75,
+    "itm": "【最终数据防线】",
+    "itmk": "TO",
+    "itme": 1000,
+    "itms": "1",
+    "itmsk": "1",
+    "pls": 0
+  },
+  {
+    "tid": 76,
+    "itm": "【最终数据防线】",
+    "itmk": "TO",
+    "itme": 1000,
+    "itms": "1",
+    "itmsk": "1",
+    "pls": 0
+  },
+  {
+    "tid": 77,
+    "itm": "【最终数据防线】",
+    "itmk": "TO",
+    "itme": 1000,
+    "itms": "1",
+    "itmsk": "1",
+    "pls": 0
+  },
+  {
+    "tid": 78,
+    "itm": "【最终数据防线】",
+    "itmk": "TO",
+    "itme": 1000,
+    "itms": "1",
+    "itmsk": "1",
+    "pls": 0
+  },
+  {
+    "tid": 79,
+    "itm": "【最终数据防线】",
+    "itmk": "TO",
+    "itme": 1000,
+    "itms": "1",
+    "itmsk": "1",
+    "pls": 0
+  },
+  {
+    "tid": 80,
+    "itm": "【最终数据防线】",
+    "itmk": "TO",
+    "itme": 1000,
+    "itms": "1",
+    "itmsk": "1",
+    "pls": 0
+  },
+  {
+    "tid": 81,
+    "itm": "脉冲防线",
+    "itmk": "TO",
+    "itme": 200,
+    "itms": "1",
+    "itmsk": "",
+    "pls": 1
+  },
+  {
+    "tid": 82,
+    "itm": "脉冲防线",
+    "itmk": "TO",
+    "itme": 200,
+    "itms": "1",
+    "itmsk": "",
+    "pls": 1
+  },
+  {
+    "tid": 83,
+    "itm": "脉冲防线",
+    "itmk": "TO",
+    "itme": 200,
+    "itms": "1",
+    "itmsk": "",
+    "pls": 1
+  },
+  {
+    "tid": 84,
+    "itm": "脉冲防线",
+    "itmk": "TO",
+    "itme": 200,
+    "itms": "1",
+    "itmsk": "",
+    "pls": 1
+  },
+  {
+    "tid": 85,
+    "itm": "地雷",
+    "itmk": "TO",
+    "itme": 200,
+    "itms": "1",
+    "itmsk": "",
+    "pls": 2
+  },
+  {
+    "tid": 86,
+    "itm": "地雷",
+    "itmk": "TO",
+    "itme": 200,
+    "itms": "1",
+    "itmsk": "",
+    "pls": 2
+  },
+  {
+    "tid": 87,
+    "itm": "地雷",
+    "itmk": "TO",
+    "itme": 200,
+    "itms": "1",
+    "itmsk": "",
+    "pls": 2
+  },
+  {
+    "tid": 88,
+    "itm": "地雷",
+    "itmk": "TO",
+    "itme": 200,
+    "itms": "1",
+    "itmsk": "",
+    "pls": 2
+  },
+  {
+    "tid": 89,
+    "itm": "地雷",
+    "itmk": "TO",
+    "itme": 200,
+    "itms": "1",
+    "itmsk": "",
+    "pls": 2
+  },
+  {
+    "tid": 90,
+    "itm": "地雷",
+    "itmk": "TO",
+    "itme": 200,
+    "itms": "1",
+    "itmsk": "",
+    "pls": 2
+  },
+  {
+    "tid": 91,
+    "itm": "地雷",
+    "itmk": "TO",
+    "itme": 200,
+    "itms": "1",
+    "itmsk": "",
+    "pls": 2
+  },
+  {
+    "tid": 92,
+    "itm": "地雷",
+    "itmk": "TO",
+    "itme": 200,
+    "itms": "1",
+    "itmsk": "",
+    "pls": 2
+  },
+  {
+    "tid": 93,
+    "itm": "杀人激光束",
+    "itmk": "TO",
+    "itme": 600,
+    "itms": "1",
+    "itmsk": "",
+    "pls": 2
+  },
+  {
+    "tid": 94,
+    "itm": "杀人激光束",
+    "itmk": "TO",
+    "itme": 600,
+    "itms": "1",
+    "itmsk": "",
+    "pls": 2
+  },
+  {
+    "tid": 95,
+    "itm": "杀人激光束",
+    "itmk": "TO",
+    "itme": 600,
+    "itms": "1",
+    "itmsk": "",
+    "pls": 2
+  },
+  {
+    "tid": 96,
+    "itm": "钢琴线",
+    "itmk": "TO",
+    "itme": 120,
+    "itms": "1",
+    "itmsk": "",
+    "pls": 3
+  },
+  {
+    "tid": 97,
+    "itm": "钢琴线",
+    "itmk": "TO",
+    "itme": 120,
+    "itms": "1",
+    "itmsk": "",
+    "pls": 3
+  },
+  {
+    "tid": 98,
+    "itm": "钢琴线",
+    "itmk": "TO",
+    "itme": 120,
+    "itms": "1",
+    "itmsk": "",
+    "pls": 3
+  },
+  {
+    "tid": 99,
+    "itm": "钢琴线",
+    "itmk": "TO",
+    "itme": 120,
+    "itms": "1",
+    "itmsk": "",
+    "pls": 3
+  },
+  {
+    "tid": 100,
+    "itm": "钢琴线",
+    "itmk": "TO",
+    "itme": 120,
+    "itms": "1",
+    "itmsk": "",
+    "pls": 3
+  },
+  {
+    "tid": 101,
+    "itm": "地雷",
+    "itmk": "TO",
+    "itme": 300,
+    "itms": "1",
+    "itmsk": "",
+    "pls": 3
+  },
+  {
+    "tid": 102,
+    "itm": "地雷",
+    "itmk": "TO",
+    "itme": 300,
+    "itms": "1",
+    "itmsk": "",
+    "pls": 3
+  },
+  {
+    "tid": 103,
+    "itm": "地雷",
+    "itmk": "TO",
+    "itme": 300,
+    "itms": "1",
+    "itmsk": "",
+    "pls": 3
+  },
+  {
+    "tid": 104,
+    "itm": "钢琴线",
+    "itmk": "TO",
+    "itme": 140,
+    "itms": "1",
+    "itmsk": "",
+    "pls": 4
+  },
+  {
+    "tid": 105,
+    "itm": "钢琴线",
+    "itmk": "TO",
+    "itme": 140,
+    "itms": "1",
+    "itmsk": "",
+    "pls": 4
+  },
+  {
+    "tid": 106,
+    "itm": "钢琴线",
+    "itmk": "TO",
+    "itme": 140,
+    "itms": "1",
+    "itmsk": "",
+    "pls": 4
+  },
+  {
+    "tid": 107,
+    "itm": "钢琴线",
+    "itmk": "TO",
+    "itme": 140,
+    "itms": "1",
+    "itmsk": "",
+    "pls": 4
+  },
+  {
+    "tid": 108,
+    "itm": "指挥中心防御装置",
+    "itmk": "TO",
+    "itme": 400,
+    "itms": "1",
+    "itmsk": "",
+    "pls": 5
+  },
+  {
+    "tid": 109,
+    "itm": "指挥中心防御装置",
+    "itmk": "TO",
+    "itme": 400,
+    "itms": "1",
+    "itmsk": "",
+    "pls": 5
+  },
+  {
+    "tid": 110,
+    "itm": "指挥中心防御装置",
+    "itmk": "TO",
+    "itme": 400,
+    "itms": "1",
+    "itmsk": "",
+    "pls": 5
+  },
+  {
+    "tid": 111,
+    "itm": "指挥中心防御装置",
+    "itmk": "TO",
+    "itme": 400,
+    "itms": "1",
+    "itmsk": "",
+    "pls": 5
+  },
+  {
+    "tid": 112,
+    "itm": "指挥中心防御装置",
+    "itmk": "TO",
+    "itme": 400,
+    "itms": "1",
+    "itmsk": "",
+    "pls": 5
+  },
+  {
+    "tid": 113,
+    "itm": "指挥中心防御装置",
+    "itmk": "TO",
+    "itme": 400,
+    "itms": "1",
+    "itmsk": "",
+    "pls": 5
+  },
+  {
+    "tid": 114,
+    "itm": "指挥中心防御装置",
+    "itmk": "TO",
+    "itme": 400,
+    "itms": "1",
+    "itmsk": "",
+    "pls": 5
+  },
+  {
+    "tid": 115,
+    "itm": "指挥中心防御装置",
+    "itmk": "TO",
+    "itme": 400,
+    "itms": "1",
+    "itmsk": "",
+    "pls": 5
+  },
+  {
+    "tid": 116,
+    "itm": "指挥中心防御装置",
+    "itmk": "TO",
+    "itme": 400,
+    "itms": "1",
+    "itmsk": "",
+    "pls": 5
+  },
+  {
+    "tid": 117,
+    "itm": "指挥中心防御装置",
+    "itmk": "TO",
+    "itme": 400,
+    "itms": "1",
+    "itmsk": "",
+    "pls": 5
+  },
+  {
+    "tid": 118,
+    "itm": "指挥中心防御装置",
+    "itmk": "TO",
+    "itme": 500,
+    "itms": "1",
+    "itmsk": "",
+    "pls": 5
+  },
+  {
+    "tid": 119,
+    "itm": "指挥中心防御装置",
+    "itmk": "TO",
+    "itme": 500,
+    "itms": "1",
+    "itmsk": "",
+    "pls": 5
+  },
+  {
+    "tid": 120,
+    "itm": "指挥中心防御装置",
+    "itmk": "TO",
+    "itme": 500,
+    "itms": "1",
+    "itmsk": "",
+    "pls": 5
+  },
+  {
+    "tid": 121,
+    "itm": "指挥中心防御装置",
+    "itmk": "TO",
+    "itme": 500,
+    "itms": "1",
+    "itmsk": "",
+    "pls": 5
+  },
+  {
+    "tid": 122,
+    "itm": "指挥中心防御装置",
+    "itmk": "TO",
+    "itme": 500,
+    "itms": "1",
+    "itmsk": "",
+    "pls": 5
+  },
+  {
+    "tid": 123,
+    "itm": "指挥中心防御装置",
+    "itmk": "TO",
+    "itme": 500,
+    "itms": "1",
+    "itmsk": "",
+    "pls": 5
+  },
+  {
+    "tid": 124,
+    "itm": "指挥中心防御装置",
+    "itmk": "TO",
+    "itme": 500,
+    "itms": "1",
+    "itmsk": "",
+    "pls": 5
+  },
+  {
+    "tid": 125,
+    "itm": "指挥中心防御装置",
+    "itmk": "TO",
+    "itme": 500,
+    "itms": "1",
+    "itmsk": "",
+    "pls": 5
+  },
+  {
+    "tid": 126,
+    "itm": "指挥中心防御装置",
+    "itmk": "TO",
+    "itme": 500,
+    "itms": "1",
+    "itmsk": "",
+    "pls": 5
+  },
+  {
+    "tid": 127,
+    "itm": "指挥中心防御装置",
+    "itmk": "TO",
+    "itme": 500,
+    "itms": "1",
+    "itmsk": "",
+    "pls": 5
+  },
+  {
+    "tid": 128,
+    "itm": "指挥中心防御装置",
+    "itmk": "TO",
+    "itme": 600,
+    "itms": "1",
+    "itmsk": "",
+    "pls": 5
+  },
+  {
+    "tid": 129,
+    "itm": "指挥中心防御装置",
+    "itmk": "TO",
+    "itme": 600,
+    "itms": "1",
+    "itmsk": "",
+    "pls": 5
+  },
+  {
+    "tid": 130,
+    "itm": "指挥中心防御装置",
+    "itmk": "TO",
+    "itme": 600,
+    "itms": "1",
+    "itmsk": "",
+    "pls": 5
+  },
+  {
+    "tid": 131,
+    "itm": "指挥中心防御装置",
+    "itmk": "TO",
+    "itme": 600,
+    "itms": "1",
+    "itmsk": "",
+    "pls": 5
+  },
+  {
+    "tid": 132,
+    "itm": "指挥中心防御装置",
+    "itmk": "TO",
+    "itme": 600,
+    "itms": "1",
+    "itmsk": "",
+    "pls": 5
+  },
+  {
+    "tid": 133,
+    "itm": "指挥中心防御装置",
+    "itmk": "TO",
+    "itme": 600,
+    "itms": "1",
+    "itmsk": "",
+    "pls": 5
+  },
+  {
+    "tid": 134,
+    "itm": "指挥中心防御装置",
+    "itmk": "TO",
+    "itme": 600,
+    "itms": "1",
+    "itmsk": "",
+    "pls": 5
+  },
+  {
+    "tid": 135,
+    "itm": "指挥中心防御装置",
+    "itmk": "TO",
+    "itme": 600,
+    "itms": "1",
+    "itmsk": "",
+    "pls": 5
+  },
+  {
+    "tid": 136,
+    "itm": "指挥中心防御装置",
+    "itmk": "TO",
+    "itme": 600,
+    "itms": "1",
+    "itmsk": "",
+    "pls": 5
+  },
+  {
+    "tid": 137,
+    "itm": "指挥中心防御装置",
+    "itmk": "TO",
+    "itme": 600,
+    "itms": "1",
+    "itmsk": "",
+    "pls": 5
+  },
+  {
+    "tid": 138,
+    "itm": "梦幻馆防御装置",
+    "itmk": "TO",
+    "itme": 400,
+    "itms": "1",
+    "itmsk": "",
+    "pls": 6
+  },
+  {
+    "tid": 139,
+    "itm": "梦幻馆防御装置",
+    "itmk": "TO",
+    "itme": 400,
+    "itms": "1",
+    "itmsk": "",
+    "pls": 6
+  },
+  {
+    "tid": 140,
+    "itm": "梦幻馆防御装置",
+    "itmk": "TO",
+    "itme": 400,
+    "itms": "1",
+    "itmsk": "",
+    "pls": 6
+  },
+  {
+    "tid": 141,
+    "itm": "梦幻馆防御装置",
+    "itmk": "TO",
+    "itme": 400,
+    "itms": "1",
+    "itmsk": "",
+    "pls": 6
+  },
+  {
+    "tid": 142,
+    "itm": "梦幻馆防御装置",
+    "itmk": "TO",
+    "itme": 400,
+    "itms": "1",
+    "itmsk": "",
+    "pls": 6
+  },
+  {
+    "tid": 143,
+    "itm": "梦幻馆防御装置",
+    "itmk": "TO",
+    "itme": 400,
+    "itms": "1",
+    "itmsk": "",
+    "pls": 6
+  },
+  {
+    "tid": 144,
+    "itm": "梦幻馆防御装置",
+    "itmk": "TO",
+    "itme": 400,
+    "itms": "1",
+    "itmsk": "",
+    "pls": 6
+  },
+  {
+    "tid": 145,
+    "itm": "梦幻馆防御装置",
+    "itmk": "TO",
+    "itme": 400,
+    "itms": "1",
+    "itmsk": "",
+    "pls": 6
+  },
+  {
+    "tid": 146,
+    "itm": "梦幻馆防御装置",
+    "itmk": "TO",
+    "itme": 400,
+    "itms": "1",
+    "itmsk": "",
+    "pls": 6
+  },
+  {
+    "tid": 147,
+    "itm": "梦幻馆防御装置",
+    "itmk": "TO",
+    "itme": 400,
+    "itms": "1",
+    "itmsk": "",
+    "pls": 6
+  },
+  {
+    "tid": 148,
+    "itm": "梦幻馆防御装置",
+    "itmk": "TO",
+    "itme": 500,
+    "itms": "1",
+    "itmsk": "",
+    "pls": 6
+  },
+  {
+    "tid": 149,
+    "itm": "梦幻馆防御装置",
+    "itmk": "TO",
+    "itme": 500,
+    "itms": "1",
+    "itmsk": "",
+    "pls": 6
+  },
+  {
+    "tid": 150,
+    "itm": "梦幻馆防御装置",
+    "itmk": "TO",
+    "itme": 500,
+    "itms": "1",
+    "itmsk": "",
+    "pls": 6
+  },
+  {
+    "tid": 151,
+    "itm": "梦幻馆防御装置",
+    "itmk": "TO",
+    "itme": 500,
+    "itms": "1",
+    "itmsk": "",
+    "pls": 6
+  },
+  {
+    "tid": 152,
+    "itm": "梦幻馆防御装置",
+    "itmk": "TO",
+    "itme": 500,
+    "itms": "1",
+    "itmsk": "",
+    "pls": 6
+  },
+  {
+    "tid": 153,
+    "itm": "梦幻馆防御装置",
+    "itmk": "TO",
+    "itme": 500,
+    "itms": "1",
+    "itmsk": "",
+    "pls": 6
+  },
+  {
+    "tid": 154,
+    "itm": "梦幻馆防御装置",
+    "itmk": "TO",
+    "itme": 500,
+    "itms": "1",
+    "itmsk": "",
+    "pls": 6
+  },
+  {
+    "tid": 155,
+    "itm": "梦幻馆防御装置",
+    "itmk": "TO",
+    "itme": 500,
+    "itms": "1",
+    "itmsk": "",
+    "pls": 6
+  },
+  {
+    "tid": 156,
+    "itm": "梦幻馆防御装置",
+    "itmk": "TO",
+    "itme": 500,
+    "itms": "1",
+    "itmsk": "",
+    "pls": 6
+  },
+  {
+    "tid": 157,
+    "itm": "梦幻馆防御装置",
+    "itmk": "TO",
+    "itme": 500,
+    "itms": "1",
+    "itmsk": "",
+    "pls": 6
+  },
+  {
+    "tid": 158,
+    "itm": "梦幻馆防御装置",
+    "itmk": "TO",
+    "itme": 600,
+    "itms": "1",
+    "itmsk": "",
+    "pls": 6
+  },
+  {
+    "tid": 159,
+    "itm": "梦幻馆防御装置",
+    "itmk": "TO",
+    "itme": 600,
+    "itms": "1",
+    "itmsk": "",
+    "pls": 6
+  },
+  {
+    "tid": 160,
+    "itm": "梦幻馆防御装置",
+    "itmk": "TO",
+    "itme": 600,
+    "itms": "1",
+    "itmsk": "",
+    "pls": 6
+  },
+  {
+    "tid": 161,
+    "itm": "梦幻馆防御装置",
+    "itmk": "TO",
+    "itme": 600,
+    "itms": "1",
+    "itmsk": "",
+    "pls": 6
+  },
+  {
+    "tid": 162,
+    "itm": "梦幻馆防御装置",
+    "itmk": "TO",
+    "itme": 600,
+    "itms": "1",
+    "itmsk": "",
+    "pls": 6
+  },
+  {
+    "tid": 163,
+    "itm": "梦幻馆防御装置",
+    "itmk": "TO",
+    "itme": 600,
+    "itms": "1",
+    "itmsk": "",
+    "pls": 6
+  },
+  {
+    "tid": 164,
+    "itm": "梦幻馆防御装置",
+    "itmk": "TO",
+    "itme": 600,
+    "itms": "1",
+    "itmsk": "",
+    "pls": 6
+  },
+  {
+    "tid": 165,
+    "itm": "梦幻馆防御装置",
+    "itmk": "TO",
+    "itme": 600,
+    "itms": "1",
+    "itmsk": "",
+    "pls": 6
+  },
+  {
+    "tid": 166,
+    "itm": "梦幻馆防御装置",
+    "itmk": "TO",
+    "itme": 600,
+    "itms": "1",
+    "itmsk": "",
+    "pls": 6
+  },
+  {
+    "tid": 167,
+    "itm": "梦幻馆防御装置",
+    "itmk": "TO",
+    "itme": 600,
+    "itms": "1",
+    "itmsk": "",
+    "pls": 6
+  },
+  {
+    "tid": 168,
+    "itm": "地雷",
+    "itmk": "TO",
+    "itme": 300,
+    "itms": "1",
+    "itmsk": "",
+    "pls": 7
+  },
+  {
+    "tid": 169,
+    "itm": "地雷",
+    "itmk": "TO",
+    "itme": 300,
+    "itms": "1",
+    "itmsk": "",
+    "pls": 7
+  },
+  {
+    "tid": 170,
+    "itm": "地雷",
+    "itmk": "TO",
+    "itme": 300,
+    "itms": "1",
+    "itmsk": "",
+    "pls": 7
+  },
+  {
+    "tid": 171,
+    "itm": "地雷",
+    "itmk": "TO",
+    "itme": 300,
+    "itms": "1",
+    "itmsk": "",
+    "pls": 7
+  },
+  {
+    "tid": 172,
+    "itm": "地雷",
+    "itmk": "TO",
+    "itme": 300,
+    "itms": "1",
+    "itmsk": "",
+    "pls": 7
+  },
+  {
+    "tid": 173,
+    "itm": "地雷",
+    "itmk": "TO",
+    "itme": 300,
+    "itms": "1",
+    "itmsk": "",
+    "pls": 8
+  },
+  {
+    "tid": 174,
+    "itm": "地雷",
+    "itmk": "TO",
+    "itme": 300,
+    "itms": "1",
+    "itmsk": "",
+    "pls": 8
+  },
+  {
+    "tid": 175,
+    "itm": "地雷",
+    "itmk": "TO",
+    "itme": 300,
+    "itms": "1",
+    "itmsk": "",
+    "pls": 8
+  },
+  {
+    "tid": 176,
+    "itm": "落穴",
+    "itmk": "TO",
+    "itme": 150,
+    "itms": "1",
+    "itmsk": "",
+    "pls": 9
+  },
+  {
+    "tid": 177,
+    "itm": "落穴",
+    "itmk": "TO",
+    "itme": 150,
+    "itms": "1",
+    "itmsk": "",
+    "pls": 9
+  },
+  {
+    "tid": 178,
+    "itm": "落穴",
+    "itmk": "TO",
+    "itme": 150,
+    "itms": "1",
+    "itmsk": "",
+    "pls": 9
+  },
+  {
+    "tid": 179,
+    "itm": "落穴",
+    "itmk": "TO",
+    "itme": 150,
+    "itms": "1",
+    "itmsk": "",
+    "pls": 9
+  },
+  {
+    "tid": 180,
+    "itm": "落穴",
+    "itmk": "TO",
+    "itme": 150,
+    "itms": "1",
+    "itmsk": "",
+    "pls": 9
+  },
+  {
+    "tid": 181,
+    "itm": "落穴",
+    "itmk": "TO",
+    "itme": 150,
+    "itms": "1",
+    "itmsk": "",
+    "pls": 9
+  },
+  {
+    "tid": 182,
+    "itm": "落穴",
+    "itmk": "TO",
+    "itme": 150,
+    "itms": "1",
+    "itmsk": "",
+    "pls": 9
+  },
+  {
+    "tid": 183,
+    "itm": "落穴",
+    "itmk": "TO",
+    "itme": 150,
+    "itms": "1",
+    "itmsk": "",
+    "pls": 9
+  },
+  {
+    "tid": 184,
+    "itm": "落穴",
+    "itmk": "TO",
+    "itme": 150,
+    "itms": "1",
+    "itmsk": "",
+    "pls": 9
+  },
+  {
+    "tid": 185,
+    "itm": "落穴",
+    "itmk": "TO",
+    "itme": 150,
+    "itms": "1",
+    "itmsk": "",
+    "pls": 9
+  },
+  {
+    "tid": 186,
+    "itm": "落穴",
+    "itmk": "TO",
+    "itme": 150,
+    "itms": "1",
+    "itmsk": "",
+    "pls": 9
+  },
+  {
+    "tid": 187,
+    "itm": "落穴",
+    "itmk": "TO",
+    "itme": 150,
+    "itms": "1",
+    "itmsk": "",
+    "pls": 9
+  },
+  {
+    "tid": 188,
+    "itm": "落穴",
+    "itmk": "TO",
+    "itme": 150,
+    "itms": "1",
+    "itmsk": "",
+    "pls": 9
+  },
+  {
+    "tid": 189,
+    "itm": "落穴",
+    "itmk": "TO",
+    "itme": 150,
+    "itms": "1",
+    "itmsk": "",
+    "pls": 9
+  },
+  {
+    "tid": 190,
+    "itm": "落穴",
+    "itmk": "TO",
+    "itme": 150,
+    "itms": "1",
+    "itmsk": "",
+    "pls": 9
+  },
+  {
+    "tid": 191,
+    "itm": "爆裂装甲",
+    "itmk": "TO",
+    "itme": 500,
+    "itms": "1",
+    "itmsk": "",
+    "pls": 9
+  },
+  {
+    "tid": 192,
+    "itm": "爆裂装甲",
+    "itmk": "TO",
+    "itme": 500,
+    "itms": "1",
+    "itmsk": "",
+    "pls": 9
+  },
+  {
+    "tid": 193,
+    "itm": "爆裂装甲",
+    "itmk": "TO",
+    "itme": 500,
+    "itms": "1",
+    "itmsk": "",
+    "pls": 9
+  },
+  {
+    "tid": 194,
+    "itm": "爆裂装甲",
+    "itmk": "TO",
+    "itme": 500,
+    "itms": "1",
+    "itmsk": "",
+    "pls": 9
+  },
+  {
+    "tid": 195,
+    "itm": "爆裂装甲",
+    "itmk": "TO",
+    "itme": 500,
+    "itms": "1",
+    "itmsk": "",
+    "pls": 9
+  },
+  {
+    "tid": 196,
+    "itm": "爆裂装甲",
+    "itmk": "TO",
+    "itme": 500,
+    "itms": "1",
+    "itmsk": "",
+    "pls": 9
+  },
+  {
+    "tid": 197,
+    "itm": "爆裂装甲",
+    "itmk": "TO",
+    "itme": 500,
+    "itms": "1",
+    "itmsk": "",
+    "pls": 9
+  },
+  {
+    "tid": 198,
+    "itm": "爆裂装甲",
+    "itmk": "TO",
+    "itme": 500,
+    "itms": "1",
+    "itmsk": "",
+    "pls": 9
+  },
+  {
+    "tid": 199,
+    "itm": "爆裂装甲",
+    "itmk": "TO",
+    "itme": 500,
+    "itms": "1",
+    "itmsk": "",
+    "pls": 9
+  },
+  {
+    "tid": 200,
+    "itm": "爆裂装甲",
+    "itmk": "TO",
+    "itme": 500,
+    "itms": "1",
+    "itmsk": "",
+    "pls": 9
+  },
+  {
+    "tid": 201,
+    "itm": "爆裂装甲",
+    "itmk": "TO",
+    "itme": 500,
+    "itms": "1",
+    "itmsk": "",
+    "pls": 9
+  },
+  {
+    "tid": 202,
+    "itm": "爆裂装甲",
+    "itmk": "TO",
+    "itme": 500,
+    "itms": "1",
+    "itmsk": "",
+    "pls": 9
+  },
+  {
+    "tid": 203,
+    "itm": "爆裂装甲",
+    "itmk": "TO",
+    "itme": 500,
+    "itms": "1",
+    "itmsk": "",
+    "pls": 9
+  },
+  {
+    "tid": 204,
+    "itm": "爆裂装甲",
+    "itmk": "TO",
+    "itme": 500,
+    "itms": "1",
+    "itmsk": "",
+    "pls": 9
+  },
+  {
+    "tid": 205,
+    "itm": "爆裂装甲",
+    "itmk": "TO",
+    "itme": 500,
+    "itms": "1",
+    "itmsk": "",
+    "pls": 9
+  },
+  {
+    "tid": 206,
+    "itm": "【奈落的落穴】",
+    "itmk": "TO",
+    "itme": 700,
+    "itms": "1",
+    "itmsk": "",
+    "pls": 9
+  },
+  {
+    "tid": 207,
+    "itm": "【奈落的落穴】",
+    "itmk": "TO",
+    "itme": 700,
+    "itms": "1",
+    "itmsk": "",
+    "pls": 9
+  },
+  {
+    "tid": 208,
+    "itm": "【奈落的落穴】",
+    "itmk": "TO",
+    "itme": 700,
+    "itms": "1",
+    "itmsk": "",
+    "pls": 9
+  },
+  {
+    "tid": 209,
+    "itm": "【奈落的落穴】",
+    "itmk": "TO",
+    "itme": 700,
+    "itms": "1",
+    "itmsk": "",
+    "pls": 9
+  },
+  {
+    "tid": 210,
+    "itm": "【奈落的落穴】",
+    "itmk": "TO",
+    "itme": 700,
+    "itms": "1",
+    "itmsk": "",
+    "pls": 9
+  },
+  {
+    "tid": 211,
+    "itm": "【奈落的落穴】",
+    "itmk": "TO",
+    "itme": 700,
+    "itms": "1",
+    "itmsk": "",
+    "pls": 9
+  },
+  {
+    "tid": 212,
+    "itm": "【奈落的落穴】",
+    "itmk": "TO",
+    "itme": 700,
+    "itms": "1",
+    "itmsk": "",
+    "pls": 9
+  },
+  {
+    "tid": 213,
+    "itm": "【奈落的落穴】",
+    "itmk": "TO",
+    "itme": 700,
+    "itms": "1",
+    "itmsk": "",
+    "pls": 9
+  },
+  {
+    "tid": 214,
+    "itm": "【奈落的落穴】",
+    "itmk": "TO",
+    "itme": 700,
+    "itms": "1",
+    "itmsk": "",
+    "pls": 9
+  },
+  {
+    "tid": 215,
+    "itm": "【奈落的落穴】",
+    "itmk": "TO",
+    "itme": 700,
+    "itms": "1",
+    "itmsk": "",
+    "pls": 9
+  },
+  {
+    "tid": 216,
+    "itm": "【奈落的落穴】",
+    "itmk": "TO",
+    "itme": 700,
+    "itms": "1",
+    "itmsk": "",
+    "pls": 9
+  },
+  {
+    "tid": 217,
+    "itm": "【奈落的落穴】",
+    "itmk": "TO",
+    "itme": 700,
+    "itms": "1",
+    "itmsk": "",
+    "pls": 9
+  },
+  {
+    "tid": 218,
+    "itm": "【奈落的落穴】",
+    "itmk": "TO",
+    "itme": 700,
+    "itms": "1",
+    "itmsk": "",
+    "pls": 9
+  },
+  {
+    "tid": 219,
+    "itm": "【奈落的落穴】",
+    "itmk": "TO",
+    "itme": 700,
+    "itms": "1",
+    "itmsk": "",
+    "pls": 9
+  },
+  {
+    "tid": 220,
+    "itm": "【奈落的落穴】",
+    "itmk": "TO",
+    "itme": 700,
+    "itms": "1",
+    "itmsk": "",
+    "pls": 9
+  },
+  {
+    "tid": 221,
+    "itm": "落穴",
+    "itmk": "TO",
+    "itme": 300,
+    "itms": "1",
+    "itmsk": "",
+    "pls": 9
+  },
+  {
+    "tid": 222,
+    "itm": "落穴",
+    "itmk": "TO",
+    "itme": 300,
+    "itms": "1",
+    "itmsk": "",
+    "pls": 9
+  },
+  {
+    "tid": 223,
+    "itm": "落穴",
+    "itmk": "TO",
+    "itme": 300,
+    "itms": "1",
+    "itmsk": "",
+    "pls": 9
+  },
+  {
+    "tid": 224,
+    "itm": "落穴",
+    "itmk": "TO",
+    "itme": 300,
+    "itms": "1",
+    "itmsk": "",
+    "pls": 9
+  },
+  {
+    "tid": 225,
+    "itm": "落穴",
+    "itmk": "TO",
+    "itme": 300,
+    "itms": "1",
+    "itmsk": "",
+    "pls": 9
+  },
+  {
+    "tid": 226,
+    "itm": "落穴",
+    "itmk": "TO",
+    "itme": 300,
+    "itms": "1",
+    "itmsk": "",
+    "pls": 9
+  },
+  {
+    "tid": 227,
+    "itm": "落穴",
+    "itmk": "TO",
+    "itme": 300,
+    "itms": "1",
+    "itmsk": "",
+    "pls": 9
+  },
+  {
+    "tid": 228,
+    "itm": "落穴",
+    "itmk": "TO",
+    "itme": 300,
+    "itms": "1",
+    "itmsk": "",
+    "pls": 9
+  },
+  {
+    "tid": 229,
+    "itm": "落穴",
+    "itmk": "TO",
+    "itme": 300,
+    "itms": "1",
+    "itmsk": "",
+    "pls": 9
+  },
+  {
+    "tid": 230,
+    "itm": "落穴",
+    "itmk": "TO",
+    "itme": 300,
+    "itms": "1",
+    "itmsk": "",
+    "pls": 9
+  },
+  {
+    "tid": 231,
+    "itm": "落穴",
+    "itmk": "TO",
+    "itme": 300,
+    "itms": "1",
+    "itmsk": "",
+    "pls": 9
+  },
+  {
+    "tid": 232,
+    "itm": "落穴",
+    "itmk": "TO",
+    "itme": 300,
+    "itms": "1",
+    "itmsk": "",
+    "pls": 9
+  },
+  {
+    "tid": 233,
+    "itm": "落穴",
+    "itmk": "TO",
+    "itme": 300,
+    "itms": "1",
+    "itmsk": "",
+    "pls": 9
+  },
+  {
+    "tid": 234,
+    "itm": "落穴",
+    "itmk": "TO",
+    "itme": 300,
+    "itms": "1",
+    "itmsk": "",
+    "pls": 9
+  },
+  {
+    "tid": 235,
+    "itm": "落穴",
+    "itmk": "TO",
+    "itme": 300,
+    "itms": "1",
+    "itmsk": "",
+    "pls": 9
+  },
+  {
+    "tid": 236,
+    "itm": "爆裂装甲",
+    "itmk": "TO",
+    "itme": 500,
+    "itms": "1",
+    "itmsk": "",
+    "pls": 9
+  },
+  {
+    "tid": 237,
+    "itm": "爆裂装甲",
+    "itmk": "TO",
+    "itme": 500,
+    "itms": "1",
+    "itmsk": "",
+    "pls": 9
+  },
+  {
+    "tid": 238,
+    "itm": "爆裂装甲",
+    "itmk": "TO",
+    "itme": 500,
+    "itms": "1",
+    "itmsk": "",
+    "pls": 9
+  },
+  {
+    "tid": 239,
+    "itm": "爆裂装甲",
+    "itmk": "TO",
+    "itme": 500,
+    "itms": "1",
+    "itmsk": "",
+    "pls": 9
+  },
+  {
+    "tid": 240,
+    "itm": "爆裂装甲",
+    "itmk": "TO",
+    "itme": 500,
+    "itms": "1",
+    "itmsk": "",
+    "pls": 9
+  },
+  {
+    "tid": 241,
+    "itm": "爆裂装甲",
+    "itmk": "TO",
+    "itme": 500,
+    "itms": "1",
+    "itmsk": "",
+    "pls": 9
+  },
+  {
+    "tid": 242,
+    "itm": "爆裂装甲",
+    "itmk": "TO",
+    "itme": 500,
+    "itms": "1",
+    "itmsk": "",
+    "pls": 9
+  },
+  {
+    "tid": 243,
+    "itm": "爆裂装甲",
+    "itmk": "TO",
+    "itme": 500,
+    "itms": "1",
+    "itmsk": "",
+    "pls": 9
+  },
+  {
+    "tid": 244,
+    "itm": "爆裂装甲",
+    "itmk": "TO",
+    "itme": 500,
+    "itms": "1",
+    "itmsk": "",
+    "pls": 9
+  },
+  {
+    "tid": 245,
+    "itm": "爆裂装甲",
+    "itmk": "TO",
+    "itme": 500,
+    "itms": "1",
+    "itmsk": "",
+    "pls": 9
+  },
+  {
+    "tid": 246,
+    "itm": "爆裂装甲",
+    "itmk": "TO",
+    "itme": 500,
+    "itms": "1",
+    "itmsk": "",
+    "pls": 9
+  },
+  {
+    "tid": 247,
+    "itm": "爆裂装甲",
+    "itmk": "TO",
+    "itme": 500,
+    "itms": "1",
+    "itmsk": "",
+    "pls": 9
+  },
+  {
+    "tid": 248,
+    "itm": "爆裂装甲",
+    "itmk": "TO",
+    "itme": 500,
+    "itms": "1",
+    "itmsk": "",
+    "pls": 9
+  },
+  {
+    "tid": 249,
+    "itm": "爆裂装甲",
+    "itmk": "TO",
+    "itme": 500,
+    "itms": "1",
+    "itmsk": "",
+    "pls": 9
+  },
+  {
+    "tid": 250,
+    "itm": "爆裂装甲",
+    "itmk": "TO",
+    "itme": 500,
+    "itms": "1",
+    "itmsk": "",
+    "pls": 9
+  },
+  {
+    "tid": 251,
+    "itm": "【奈落的落穴】",
+    "itmk": "TO",
+    "itme": 700,
+    "itms": "1",
+    "itmsk": "",
+    "pls": 9
+  },
+  {
+    "tid": 252,
+    "itm": "【奈落的落穴】",
+    "itmk": "TO",
+    "itme": 700,
+    "itms": "1",
+    "itmsk": "",
+    "pls": 9
+  },
+  {
+    "tid": 253,
+    "itm": "【奈落的落穴】",
+    "itmk": "TO",
+    "itme": 700,
+    "itms": "1",
+    "itmsk": "",
+    "pls": 9
+  },
+  {
+    "tid": 254,
+    "itm": "【奈落的落穴】",
+    "itmk": "TO",
+    "itme": 700,
+    "itms": "1",
+    "itmsk": "",
+    "pls": 9
+  },
+  {
+    "tid": 255,
+    "itm": "【奈落的落穴】",
+    "itmk": "TO",
+    "itme": 700,
+    "itms": "1",
+    "itmsk": "",
+    "pls": 9
+  },
+  {
+    "tid": 256,
+    "itm": "【奈落的落穴】",
+    "itmk": "TO",
+    "itme": 700,
+    "itms": "1",
+    "itmsk": "",
+    "pls": 9
+  },
+  {
+    "tid": 257,
+    "itm": "【奈落的落穴】",
+    "itmk": "TO",
+    "itme": 700,
+    "itms": "1",
+    "itmsk": "",
+    "pls": 9
+  },
+  {
+    "tid": 258,
+    "itm": "【奈落的落穴】",
+    "itmk": "TO",
+    "itme": 700,
+    "itms": "1",
+    "itmsk": "",
+    "pls": 9
+  },
+  {
+    "tid": 259,
+    "itm": "【奈落的落穴】",
+    "itmk": "TO",
+    "itme": 700,
+    "itms": "1",
+    "itmsk": "",
+    "pls": 9
+  },
+  {
+    "tid": 260,
+    "itm": "【奈落的落穴】",
+    "itmk": "TO",
+    "itme": 700,
+    "itms": "1",
+    "itmsk": "",
+    "pls": 9
+  },
+  {
+    "tid": 261,
+    "itm": "【奈落的落穴】",
+    "itmk": "TO",
+    "itme": 700,
+    "itms": "1",
+    "itmsk": "",
+    "pls": 9
+  },
+  {
+    "tid": 262,
+    "itm": "【奈落的落穴】",
+    "itmk": "TO",
+    "itme": 700,
+    "itms": "1",
+    "itmsk": "",
+    "pls": 9
+  },
+  {
+    "tid": 263,
+    "itm": "【奈落的落穴】",
+    "itmk": "TO",
+    "itme": 700,
+    "itms": "1",
+    "itmsk": "",
+    "pls": 9
+  },
+  {
+    "tid": 264,
+    "itm": "【奈落的落穴】",
+    "itmk": "TO",
+    "itme": 700,
+    "itms": "1",
+    "itmsk": "",
+    "pls": 9
+  },
+  {
+    "tid": 265,
+    "itm": "【奈落的落穴】",
+    "itmk": "TO",
+    "itme": 700,
+    "itms": "1",
+    "itmsk": "",
+    "pls": 9
+  },
+  {
+    "tid": 266,
+    "itm": "地雷",
+    "itmk": "TO",
+    "itme": 300,
+    "itms": "1",
+    "itmsk": "",
+    "pls": 14
+  },
+  {
+    "tid": 267,
+    "itm": "地雷",
+    "itmk": "TO",
+    "itme": 300,
+    "itms": "1",
+    "itmsk": "",
+    "pls": 14
+  },
+  {
+    "tid": 268,
+    "itm": "地雷",
+    "itmk": "TO",
+    "itme": 300,
+    "itms": "1",
+    "itmsk": "",
+    "pls": 14
+  },
+  {
+    "tid": 269,
+    "itm": "地雷",
+    "itmk": "TO",
+    "itme": 300,
+    "itms": "1",
+    "itmsk": "",
+    "pls": 14
+  },
+  {
+    "tid": 270,
+    "itm": "地雷",
+    "itmk": "TO",
+    "itme": 300,
+    "itms": "1",
+    "itmsk": "",
+    "pls": 14
+  },
+  {
+    "tid": 271,
+    "itm": "地雷",
+    "itmk": "TO",
+    "itme": 300,
+    "itms": "1",
+    "itmsk": "",
+    "pls": 14
+  },
+  {
+    "tid": 272,
+    "itm": "地雷",
+    "itmk": "TO",
+    "itme": 300,
+    "itms": "1",
+    "itmsk": "",
+    "pls": 14
+  },
+  {
+    "tid": 273,
+    "itm": "地雷",
+    "itmk": "TO",
+    "itme": 300,
+    "itms": "1",
+    "itmsk": "",
+    "pls": 14
+  },
+  {
+    "tid": 274,
+    "itm": "捕兽器",
+    "itmk": "TO",
+    "itme": 240,
+    "itms": "1",
+    "itmsk": "",
+    "pls": 16
+  },
+  {
+    "tid": 275,
+    "itm": "捕兽器",
+    "itmk": "TO",
+    "itme": 240,
+    "itms": "1",
+    "itmsk": "",
+    "pls": 16
+  },
+  {
+    "tid": 276,
+    "itm": "捕兽器",
+    "itmk": "TO",
+    "itme": 240,
+    "itms": "1",
+    "itmsk": "",
+    "pls": 16
+  },
+  {
+    "tid": 277,
+    "itm": "捕兽器",
+    "itmk": "TO",
+    "itme": 240,
+    "itms": "1",
+    "itmsk": "",
+    "pls": 16
+  },
+  {
+    "tid": 278,
+    "itm": "捕兽器",
+    "itmk": "TO",
+    "itme": 240,
+    "itms": "1",
+    "itmsk": "",
+    "pls": 16
+  },
+  {
+    "tid": 279,
+    "itm": "捕兽器",
+    "itmk": "TO",
+    "itme": 240,
+    "itms": "1",
+    "itmsk": "",
+    "pls": 16
+  },
+  {
+    "tid": 280,
+    "itm": "捕兽器",
+    "itmk": "TO",
+    "itme": 240,
+    "itms": "1",
+    "itmsk": "",
+    "pls": 16
+  },
+  {
+    "tid": 281,
+    "itm": "捕兽器",
+    "itmk": "TO",
+    "itme": 240,
+    "itms": "1",
+    "itmsk": "",
+    "pls": 16
+  },
+  {
+    "tid": 282,
+    "itm": "捕兽器",
+    "itmk": "TO",
+    "itme": 240,
+    "itms": "1",
+    "itmsk": "",
+    "pls": 16
+  },
+  {
+    "tid": 283,
+    "itm": "捕兽器",
+    "itmk": "TO",
+    "itme": 240,
+    "itms": "1",
+    "itmsk": "",
+    "pls": 16
+  },
+  {
+    "tid": 284,
+    "itm": "学院都市防御装置",
+    "itmk": "TO",
+    "itme": 400,
+    "itms": "1",
+    "itmsk": "",
+    "pls": 17
+  },
+  {
+    "tid": 285,
+    "itm": "学院都市防御装置",
+    "itmk": "TO",
+    "itme": 400,
+    "itms": "1",
+    "itmsk": "",
+    "pls": 17
+  },
+  {
+    "tid": 286,
+    "itm": "学院都市防御装置",
+    "itmk": "TO",
+    "itme": 400,
+    "itms": "1",
+    "itmsk": "",
+    "pls": 17
+  },
+  {
+    "tid": 287,
+    "itm": "学院都市防御装置",
+    "itmk": "TO",
+    "itme": 400,
+    "itms": "1",
+    "itmsk": "",
+    "pls": 17
+  },
+  {
+    "tid": 288,
+    "itm": "学院都市防御装置",
+    "itmk": "TO",
+    "itme": 400,
+    "itms": "1",
+    "itmsk": "",
+    "pls": 17
+  },
+  {
+    "tid": 289,
+    "itm": "学院都市防御装置",
+    "itmk": "TO",
+    "itme": 400,
+    "itms": "1",
+    "itmsk": "",
+    "pls": 17
+  },
+  {
+    "tid": 290,
+    "itm": "学院都市防御装置",
+    "itmk": "TO",
+    "itme": 400,
+    "itms": "1",
+    "itmsk": "",
+    "pls": 17
+  },
+  {
+    "tid": 291,
+    "itm": "学院都市防御装置",
+    "itmk": "TO",
+    "itme": 400,
+    "itms": "1",
+    "itmsk": "",
+    "pls": 17
+  },
+  {
+    "tid": 292,
+    "itm": "学院都市防御装置",
+    "itmk": "TO",
+    "itme": 400,
+    "itms": "1",
+    "itmsk": "",
+    "pls": 17
+  },
+  {
+    "tid": 293,
+    "itm": "学院都市防御装置",
+    "itmk": "TO",
+    "itme": 400,
+    "itms": "1",
+    "itmsk": "",
+    "pls": 17
+  },
+  {
+    "tid": 294,
+    "itm": "学院都市防御装置",
+    "itmk": "TO",
+    "itme": 500,
+    "itms": "1",
+    "itmsk": "",
+    "pls": 17
+  },
+  {
+    "tid": 295,
+    "itm": "学院都市防御装置",
+    "itmk": "TO",
+    "itme": 500,
+    "itms": "1",
+    "itmsk": "",
+    "pls": 17
+  },
+  {
+    "tid": 296,
+    "itm": "学院都市防御装置",
+    "itmk": "TO",
+    "itme": 500,
+    "itms": "1",
+    "itmsk": "",
+    "pls": 17
+  },
+  {
+    "tid": 297,
+    "itm": "学院都市防御装置",
+    "itmk": "TO",
+    "itme": 500,
+    "itms": "1",
+    "itmsk": "",
+    "pls": 17
+  },
+  {
+    "tid": 298,
+    "itm": "学院都市防御装置",
+    "itmk": "TO",
+    "itme": 500,
+    "itms": "1",
+    "itmsk": "",
+    "pls": 17
+  },
+  {
+    "tid": 299,
+    "itm": "学院都市防御装置",
+    "itmk": "TO",
+    "itme": 500,
+    "itms": "1",
+    "itmsk": "",
+    "pls": 17
+  },
+  {
+    "tid": 300,
+    "itm": "学院都市防御装置",
+    "itmk": "TO",
+    "itme": 500,
+    "itms": "1",
+    "itmsk": "",
+    "pls": 17
+  },
+  {
+    "tid": 301,
+    "itm": "学院都市防御装置",
+    "itmk": "TO",
+    "itme": 500,
+    "itms": "1",
+    "itmsk": "",
+    "pls": 17
+  },
+  {
+    "tid": 302,
+    "itm": "学院都市防御装置",
+    "itmk": "TO",
+    "itme": 500,
+    "itms": "1",
+    "itmsk": "",
+    "pls": 17
+  },
+  {
+    "tid": 303,
+    "itm": "学院都市防御装置",
+    "itmk": "TO",
+    "itme": 500,
+    "itms": "1",
+    "itmsk": "",
+    "pls": 17
+  },
+  {
+    "tid": 304,
+    "itm": "学院都市防御装置",
+    "itmk": "TO",
+    "itme": 600,
+    "itms": "1",
+    "itmsk": "",
+    "pls": 17
+  },
+  {
+    "tid": 305,
+    "itm": "学院都市防御装置",
+    "itmk": "TO",
+    "itme": 600,
+    "itms": "1",
+    "itmsk": "",
+    "pls": 17
+  },
+  {
+    "tid": 306,
+    "itm": "学院都市防御装置",
+    "itmk": "TO",
+    "itme": 600,
+    "itms": "1",
+    "itmsk": "",
+    "pls": 17
+  },
+  {
+    "tid": 307,
+    "itm": "学院都市防御装置",
+    "itmk": "TO",
+    "itme": 600,
+    "itms": "1",
+    "itmsk": "",
+    "pls": 17
+  },
+  {
+    "tid": 308,
+    "itm": "学院都市防御装置",
+    "itmk": "TO",
+    "itme": 600,
+    "itms": "1",
+    "itmsk": "",
+    "pls": 17
+  },
+  {
+    "tid": 309,
+    "itm": "学院都市防御装置",
+    "itmk": "TO",
+    "itme": 600,
+    "itms": "1",
+    "itmsk": "",
+    "pls": 17
+  },
+  {
+    "tid": 310,
+    "itm": "学院都市防御装置",
+    "itmk": "TO",
+    "itme": 600,
+    "itms": "1",
+    "itmsk": "",
+    "pls": 17
+  },
+  {
+    "tid": 311,
+    "itm": "学院都市防御装置",
+    "itmk": "TO",
+    "itme": 600,
+    "itms": "1",
+    "itmsk": "",
+    "pls": 17
+  },
+  {
+    "tid": 312,
+    "itm": "学院都市防御装置",
+    "itmk": "TO",
+    "itme": 600,
+    "itms": "1",
+    "itmsk": "",
+    "pls": 17
+  },
+  {
+    "tid": 313,
+    "itm": "学院都市防御装置",
+    "itmk": "TO",
+    "itme": 600,
+    "itms": "1",
+    "itmsk": "",
+    "pls": 17
+  },
+  {
+    "tid": 314,
+    "itm": "机枪防线",
+    "itmk": "TO",
+    "itme": 400,
+    "itms": "1",
+    "itmsk": "",
+    "pls": 21
+  },
+  {
+    "tid": 315,
+    "itm": "机枪防线",
+    "itmk": "TO",
+    "itme": 400,
+    "itms": "1",
+    "itmsk": "",
+    "pls": 21
+  },
+  {
+    "tid": 316,
+    "itm": "机枪防线",
+    "itmk": "TO",
+    "itme": 400,
+    "itms": "1",
+    "itmsk": "",
+    "pls": 21
+  },
+  {
+    "tid": 317,
+    "itm": "机枪防线",
+    "itmk": "TO",
+    "itme": 400,
+    "itms": "1",
+    "itmsk": "",
+    "pls": 21
+  },
+  {
+    "tid": 318,
+    "itm": "机枪防线",
+    "itmk": "TO",
+    "itme": 400,
+    "itms": "1",
+    "itmsk": "",
+    "pls": 21
+  },
+  {
+    "tid": 319,
+    "itm": "机枪防线",
+    "itmk": "TO",
+    "itme": 400,
+    "itms": "1",
+    "itmsk": "",
+    "pls": 21
+  },
+  {
+    "tid": 320,
+    "itm": "机枪防线",
+    "itmk": "TO",
+    "itme": 400,
+    "itms": "1",
+    "itmsk": "",
+    "pls": 21
+  },
+  {
+    "tid": 321,
+    "itm": "机枪防线",
+    "itmk": "TO",
+    "itme": 400,
+    "itms": "1",
+    "itmsk": "",
+    "pls": 21
+  },
+  {
+    "tid": 322,
+    "itm": "火炮防线",
+    "itmk": "TO",
+    "itme": 500,
+    "itms": "1",
+    "itmsk": "",
+    "pls": 21
+  },
+  {
+    "tid": 323,
+    "itm": "火炮防线",
+    "itmk": "TO",
+    "itme": 500,
+    "itms": "1",
+    "itmsk": "",
+    "pls": 21
+  },
+  {
+    "tid": 324,
+    "itm": "火炮防线",
+    "itmk": "TO",
+    "itme": 500,
+    "itms": "1",
+    "itmsk": "",
+    "pls": 21
+  },
+  {
+    "tid": 325,
+    "itm": "火炮防线",
+    "itmk": "TO",
+    "itme": 500,
+    "itms": "1",
+    "itmsk": "",
+    "pls": 21
+  },
+  {
+    "tid": 326,
+    "itm": "火炮防线",
+    "itmk": "TO",
+    "itme": 500,
+    "itms": "1",
+    "itmsk": "",
+    "pls": 21
+  },
+  {
+    "tid": 327,
+    "itm": "火炮防线",
+    "itmk": "TO",
+    "itme": 500,
+    "itms": "1",
+    "itmsk": "",
+    "pls": 21
+  },
+  {
+    "tid": 328,
+    "itm": "电脑防线",
+    "itmk": "TO",
+    "itme": 600,
+    "itms": "1",
+    "itmsk": "",
+    "pls": 21
+  },
+  {
+    "tid": 329,
+    "itm": "电脑防线",
+    "itmk": "TO",
+    "itme": 600,
+    "itms": "1",
+    "itmsk": "",
+    "pls": 21
+  },
+  {
+    "tid": 330,
+    "itm": "电脑防线",
+    "itmk": "TO",
+    "itme": 600,
+    "itms": "1",
+    "itmsk": "",
+    "pls": 21
+  },
+  {
+    "tid": 331,
+    "itm": "电脑防线",
+    "itmk": "TO",
+    "itme": 600,
+    "itms": "1",
+    "itmsk": "",
+    "pls": 21
+  },
+  {
+    "tid": 332,
+    "itm": "地雷",
+    "itmk": "TO",
+    "itme": 300,
+    "itms": "1",
+    "itmsk": "",
+    "pls": 27
+  },
+  {
+    "tid": 333,
+    "itm": "地雷",
+    "itmk": "TO",
+    "itme": 300,
+    "itms": "1",
+    "itmsk": "",
+    "pls": 27
+  },
+  {
+    "tid": 334,
+    "itm": "地雷",
+    "itmk": "TO",
+    "itme": 300,
+    "itms": "1",
+    "itmsk": "",
+    "pls": 27
+  },
+  {
+    "tid": 335,
+    "itm": "地雷",
+    "itmk": "TO",
+    "itme": 300,
+    "itms": "1",
+    "itmsk": "",
+    "pls": 27
+  },
+  {
+    "tid": 336,
+    "itm": "地雷",
+    "itmk": "TO",
+    "itme": 300,
+    "itms": "1",
+    "itmsk": "",
+    "pls": 27
+  },
+  {
+    "tid": 337,
+    "itm": "地雷",
+    "itmk": "TO",
+    "itme": 300,
+    "itms": "1",
+    "itmsk": "",
+    "pls": 27
+  },
+  {
+    "tid": 338,
+    "itm": "地雷",
+    "itmk": "TO",
+    "itme": 300,
+    "itms": "1",
+    "itmsk": "",
+    "pls": 28
+  },
+  {
+    "tid": 339,
+    "itm": "地雷",
+    "itmk": "TO",
+    "itme": 300,
+    "itms": "1",
+    "itmsk": "",
+    "pls": 28
+  },
+  {
+    "tid": 340,
+    "itm": "地雷",
+    "itmk": "TO",
+    "itme": 300,
+    "itms": "1",
+    "itmsk": "",
+    "pls": 28
+  },
+  {
+    "tid": 341,
+    "itm": "地雷",
+    "itmk": "TO",
+    "itme": 300,
+    "itms": "1",
+    "itmsk": "",
+    "pls": 28
+  },
+  {
+    "tid": 342,
+    "itm": "地雷",
+    "itmk": "TO",
+    "itme": 300,
+    "itms": "1",
+    "itmsk": "",
+    "pls": 28
+  },
+  {
+    "tid": 343,
+    "itm": "地雷",
+    "itmk": "TO",
+    "itme": 300,
+    "itms": "1",
+    "itmsk": "",
+    "pls": 28
+  },
+  {
+    "tid": 344,
+    "itm": "地雷",
+    "itmk": "TO",
+    "itme": 300,
+    "itms": "1",
+    "itmsk": "",
+    "pls": 28
+  },
+  {
+    "tid": 345,
+    "itm": "地雷",
+    "itmk": "TO",
+    "itme": 300,
+    "itms": "1",
+    "itmsk": "",
+    "pls": 28
+  },
+  {
+    "tid": 346,
+    "itm": "★阔剑地雷★",
+    "itmk": "TO",
+    "itme": 450,
+    "itms": "1",
+    "itmsk": "",
+    "pls": 28
+  },
+  {
+    "tid": 347,
+    "itm": "★阔剑地雷★",
+    "itmk": "TO",
+    "itme": 450,
+    "itms": "1",
+    "itmsk": "",
+    "pls": 28
+  },
+  {
+    "tid": 348,
+    "itm": "★阔剑地雷★",
+    "itmk": "TO",
+    "itme": 450,
+    "itms": "1",
+    "itmsk": "",
+    "pls": 28
+  },
+  {
+    "tid": 349,
+    "itm": "★阔剑地雷★",
+    "itmk": "TO",
+    "itme": 450,
+    "itms": "1",
+    "itmsk": "",
+    "pls": 28
+  },
+  {
+    "tid": 350,
+    "itm": "★中子地雷★",
+    "itmk": "TO",
+    "itme": 800,
+    "itms": "1",
+    "itmsk": "",
+    "pls": 28
+  },
+  {
+    "tid": 351,
+    "itm": "★中子地雷★",
+    "itmk": "TO",
+    "itme": 800,
+    "itms": "1",
+    "itmsk": "",
+    "pls": 28
+  },
+  {
+    "tid": 352,
+    "itm": "★中子地雷★",
+    "itmk": "TO",
+    "itme": 800,
+    "itms": "1",
+    "itmsk": "",
+    "pls": 28
+  },
+  {
+    "tid": 353,
+    "itm": "绳索",
+    "itmk": "TO",
+    "itme": 120,
+    "itms": "1",
+    "itmsk": "",
+    "pls": 29
+  },
+  {
+    "tid": 354,
+    "itm": "绳索",
+    "itmk": "TO",
+    "itme": 120,
+    "itms": "1",
+    "itmsk": "",
+    "pls": 29
+  },
+  {
+    "tid": 355,
+    "itm": "绳索",
+    "itmk": "TO",
+    "itme": 120,
+    "itms": "1",
+    "itmsk": "",
+    "pls": 29
+  },
+  {
+    "tid": 356,
+    "itm": "绳索",
+    "itmk": "TO",
+    "itme": 120,
+    "itms": "1",
+    "itmsk": "",
+    "pls": 29
+  },
+  {
+    "tid": 357,
+    "itm": "绳索",
+    "itmk": "TO",
+    "itme": 120,
+    "itms": "1",
+    "itmsk": "",
+    "pls": 29
+  },
+  {
+    "tid": 358,
+    "itm": "圣石之种",
+    "itmk": "TO",
+    "itme": 240,
+    "itms": "1",
+    "itmsk": "",
+    "pls": 29
+  },
+  {
+    "tid": 359,
+    "itm": "圣石之种",
+    "itmk": "TO",
+    "itme": 240,
+    "itms": "1",
+    "itmsk": "",
+    "pls": 29
+  },
+  {
+    "tid": 360,
+    "itm": "圣石之种",
+    "itmk": "TO",
+    "itme": 240,
+    "itms": "1",
+    "itmsk": "",
+    "pls": 29
+  },
+  {
+    "tid": 361,
+    "itm": "圣石之种",
+    "itmk": "TO",
+    "itme": 240,
+    "itms": "1",
+    "itmsk": "",
+    "pls": 29
+  },
+  {
+    "tid": 362,
+    "itm": "圣石之种",
+    "itmk": "TO",
+    "itme": 240,
+    "itms": "1",
+    "itmsk": "",
+    "pls": 29
+  },
+  {
+    "tid": 363,
+    "itm": "对魔物用陷阱群",
+    "itmk": "TO",
+    "itme": 240,
+    "itms": "1",
+    "itmsk": "",
+    "pls": 33
+  },
+  {
+    "tid": 364,
+    "itm": "对魔物用陷阱群",
+    "itmk": "TO",
+    "itme": 240,
+    "itms": "1",
+    "itmsk": "",
+    "pls": 33
+  },
+  {
+    "tid": 365,
+    "itm": "对魔物用陷阱群",
+    "itmk": "TO",
+    "itme": 240,
+    "itms": "1",
+    "itmsk": "",
+    "pls": 33
+  },
+  {
+    "tid": 366,
+    "itm": "对魔物用陷阱群",
+    "itmk": "TO",
+    "itme": 240,
+    "itms": "1",
+    "itmsk": "",
+    "pls": 33
+  },
+  {
+    "tid": 367,
+    "itm": "对魔物用陷阱群",
+    "itmk": "TO",
+    "itme": 240,
+    "itms": "1",
+    "itmsk": "",
+    "pls": 33
+  },
+  {
+    "tid": 368,
+    "itm": "地雷",
+    "itmk": "TO",
+    "itme": 300,
+    "itms": "1",
+    "itmsk": "",
+    "pls": 99
+  },
+  {
+    "tid": 369,
+    "itm": "地雷",
+    "itmk": "TO",
+    "itme": 300,
+    "itms": "1",
+    "itmsk": "",
+    "pls": 99
+  },
+  {
+    "tid": 370,
+    "itm": "地雷",
+    "itmk": "TO",
+    "itme": 300,
+    "itms": "1",
+    "itmsk": "",
+    "pls": 99
+  },
+  {
+    "tid": 371,
+    "itm": "地雷",
+    "itmk": "TO",
+    "itme": 300,
+    "itms": "1",
+    "itmsk": "",
+    "pls": 99
+  },
+  {
+    "tid": 372,
+    "itm": "地雷",
+    "itmk": "TO",
+    "itme": 300,
+    "itms": "1",
+    "itmsk": "",
+    "pls": 99
+  },
+  {
+    "tid": 373,
+    "itm": "地雷",
+    "itmk": "TO",
+    "itme": 300,
+    "itms": "1",
+    "itmsk": "",
+    "pls": 99
+  },
+  {
+    "tid": 374,
+    "itm": "摧泪喷雾剂",
+    "itmk": "TO",
+    "itme": 150,
+    "itms": "1",
+    "itmsk": "",
+    "pls": 99
+  },
+  {
+    "tid": 375,
+    "itm": "摧泪喷雾剂",
+    "itmk": "TO",
+    "itme": 150,
+    "itms": "1",
+    "itmsk": "",
+    "pls": 99
+  },
+  {
+    "tid": 376,
+    "itm": "摧泪喷雾剂",
+    "itmk": "TO",
+    "itme": 150,
+    "itms": "1",
+    "itmsk": "",
+    "pls": 99
+  },
+  {
+    "tid": 377,
+    "itm": "★防御结界★",
+    "itmk": "TO",
+    "itme": 400,
+    "itms": "1",
+    "itmsk": "",
+    "pls": 99
+  },
+  {
+    "tid": 378,
+    "itm": "★防御结界★",
+    "itmk": "TO",
+    "itme": 400,
+    "itms": "1",
+    "itmsk": "",
+    "pls": 99
+  },
+  {
+    "tid": 379,
+    "itm": "★全地图唯一的野生高伤阔剑地雷★",
+    "itmk": "TO",
+    "itme": 800,
+    "itms": "1",
+    "itmsk": "",
+    "pls": 99
+  }
+]

--- a/mogoDB.md/README.md
+++ b/mogoDB.md/README.md
@@ -118,15 +118,18 @@
 上述集合结构请参考 `backend/src/models` 中的同名模型文件。
 
 ## 初始数据导入
-项目提供了 `../data` 目录下的 `gameinfo.json` 与 `shopitems.json`，用于快速初始化数据库。
+项目提供了 `../data` 目录下的 `gameinfo.json`、`shopitems.json`、`mapareas.json`、`mapitems.json` 与 `maptraps.json`，用于快速初始化数据库。
 
 1. 进入项目根目录，确保 MongoDB 服务已启动。
 2. 执行以下命令导入初始数据：
    ```bash
    mongoimport --db dts --collection gameinfos --file ../data/gameinfo.json --jsonArray
- mongoimport --db dts --collection shopitems --file ../data/shopitems.json --jsonArray
+   mongoimport --db dts --collection shopitems --file ../data/shopitems.json --jsonArray
+   mongoimport --db dts --collection mapareas --file ../data/mapareas.json --jsonArray
+   mongoimport --db dts --collection mapitems --file ../data/mapitems.json --jsonArray
+   mongoimport --db dts --collection maptraps --file ../data/maptraps.json --jsonArray
   ```
-3. 导入完成后即可获得与原作一致的基础记录与商店物品。
+3. 导入完成后即可获得与原作一致的基础记录、商店物品以及地图物品和陷阱数据。
 
 ## 单局玩家绑定字段
 为用户集合新增 `lastgame` 与 `lastpid` 字段以记录当前游戏局及绑定的玩家：


### PR DESCRIPTION
## Summary
- introduce `maptraps.json` converted from original trap configs
- import map traps during database initialization and game start
- add search trap logic based on map danger
- deduct HP when triggering a trap
- document trap data import steps

## Testing
- `npm test` (fails: Error: no test specified)
- `npm test` in frontend (fails: Missing script `test`)


------
https://chatgpt.com/codex/tasks/task_e_6875e7989808832288e8cfdb58a7ba7b