### PR TITLE
Fix item pickup flow to use search memory

### DIFF
--- a/backend/src/controllers/playerController.js
+++ b/backend/src/controllers/playerController.js
@@ -220,7 +220,7 @@ exports.search = async (req, res) => {
         itm: item.itm,
         itmk: item.itmk,
         itme: item.itme,
-        itms: item.itms,
+        itms: String(item.itms),
         itmsk: item.itmsk,
         pls: item.pls
       });
@@ -479,7 +479,7 @@ exports.equip = async (req, res) => {
           player[slotName],
           player[`${slotName}k`],
           player[`${slotName}e`],
-          player[`${slotName}s`],
+          String(player[`${slotName}s`]),
           player[`${slotName}sk`]
         );
       }
@@ -591,7 +591,7 @@ exports.pickReplace = async (req, res) => {
     const dropName = player[`itm${index}`];
     const dropKind = player[`itmk${index}`];
     const dropEffect = player[`itme${index}`];
-    const dropUses = player[`itms${index}`];
+    const dropUses = String(player[`itms${index}`]);
     const dropSkill = player[`itmsk${index}`];
 
     if (dropName) {
@@ -656,7 +656,7 @@ exports.pickEquip = async (req, res) => {
           player[slotName],
           player[`${slotName}k`],
           player[`${slotName}e`],
-          player[`${slotName}s`],
+          String(player[`${slotName}s`]),
           player[`${slotName}sk`]
         );
       }

--- a/backend/src/controllers/playerController.js
+++ b/backend/src/controllers/playerController.js
@@ -4,7 +4,7 @@ const MapTrap = require('../models/MapTrap');
 const GameInfo = require('../models/GameInfo');
 const MapArea = require('../models/MapArea');
 const Club = require('../models/Club');
-const { dropMapItem } = require('../utils/item');
+const { dropMapItem, restoreMemoryItem } = require('../utils/item');
 
 const START_THRESHOLD = 20;
 
@@ -77,17 +77,6 @@ exports.clubs = async (req, res) => {
   }
 };
 
-async function dropMapItem(pls, name, kind, effect, uses, skill) {
-  if (!name) return;
-  await MapItem.create({
-    itm: name,
-    itmk: kind,
-    itme: effect,
-    itms: uses,
-    itmsk: skill,
-    pls
-  });
-}
 
 
 exports.enter = async (req, res) => {
@@ -155,6 +144,8 @@ exports.move = async (req, res) => {
     const player = await Player.findOne({ pid, uid: req.user._id });
     if (!player) return res.status(404).json({ msg: '玩家不存在' });
 
+    await restoreMemoryItem(player);
+
     applyRest(player);
 
     const spCost = 20 + Math.floor(Math.random() * 21) - 10;
@@ -183,6 +174,8 @@ exports.search = async (req, res) => {
     }
   const player = await Player.findOne({ pid, uid: req.user._id });
   if (!player) return res.status(404).json({ msg: '玩家不存在' });
+
+  await restoreMemoryItem(player);
 
   applyRest(player);
   const spCost = 10 + Math.floor(Math.random() * 11) - 5;
@@ -221,6 +214,16 @@ exports.search = async (req, res) => {
     const items = await MapItem.find({ pls: player.pls });
     if (items.length && Math.random() < ITEM_FIND_RATE) {
       const item = items[Math.floor(Math.random() * items.length)];
+      await MapItem.deleteOne({ _id: item._id });
+      player.searchmemory = JSON.stringify({
+        id: String(item._id),
+        itm: item.itm,
+        itmk: item.itmk,
+        itme: item.itme,
+        itms: item.itms,
+        itmsk: item.itmsk,
+        pls: item.pls
+      });
       log += `你发现了${item.itm}。<br>`;
       await player.save();
       return res.json({ log, player, item });
@@ -292,10 +295,12 @@ exports.pickItem = async (req, res) => {
       return res.status(404).json({ msg: '玩家不存在' });
     }
 
-    const item = await MapItem.findOneAndDelete({ _id: itemId, pls: player.pls });
-    if (!item) {
+    const memory = player.searchmemory ? JSON.parse(player.searchmemory) : null;
+    if (!memory || memory.id !== itemId) {
       return res.status(400).json({ msg: '物品不存在' });
     }
+
+    const item = memory;
 
     let slot = -1;
     for (let i = 0; i < 5; i++) {
@@ -310,6 +315,7 @@ exports.pickItem = async (req, res) => {
     player[`itme${slot}`] = item.itme;
     player[`itms${slot}`] = item.itms;
     player[`itmsk${slot}`] = item.itmsk;
+    player.searchmemory = '';
     await player.save();
     res.json({ msg: `获得了${item.itm}`, player });
   } catch (err) {
@@ -576,10 +582,11 @@ exports.pickReplace = async (req, res) => {
       return res.status(400).json({ msg: '物品编号错误' });
     }
 
-    const item = await MapItem.findOneAndDelete({ _id: itemId, pls: player.pls });
-    if (!item) {
+    const memory = player.searchmemory ? JSON.parse(player.searchmemory) : null;
+    if (!memory || memory.id !== itemId) {
       return res.status(400).json({ msg: '物品不存在' });
     }
+    const item = memory;
 
     const dropName = player[`itm${index}`];
     const dropKind = player[`itmk${index}`];
@@ -603,6 +610,7 @@ exports.pickReplace = async (req, res) => {
     player[`itme${index}`] = item.itme;
     player[`itms${index}`] = item.itms;
     player[`itmsk${index}`] = item.itmsk;
+    player.searchmemory = '';
 
     await player.save();
     res.json({ msg: `获得了${item.itm}`, player, dropName });
@@ -618,8 +626,9 @@ exports.pickEquip = async (req, res) => {
     const player = await Player.findOne({ pid, uid: req.user._id });
     if (!player) return res.status(404).json({ msg: '玩家不存在' });
 
-    const item = await MapItem.findOne({ _id: itemId, pls: player.pls });
-    if (!item) return res.status(400).json({ msg: '物品不存在' });
+    const memory = player.searchmemory ? JSON.parse(player.searchmemory) : null;
+    if (!memory || memory.id !== itemId) return res.status(400).json({ msg: '物品不存在' });
+    const item = memory;
 
     let slotName = '';
     if (item.itmk.startsWith('W')) slotName = 'wep';
@@ -659,7 +668,7 @@ exports.pickEquip = async (req, res) => {
     player[`${slotName}s`] = item.itms;
     player[`${slotName}sk`] = item.itmsk;
 
-    await MapItem.deleteOne({ _id: item._id });
+    player.searchmemory = '';
     await player.save();
     res.json({ msg: `装备了${item.itm}`, player });
   } catch (err) {

--- a/backend/src/utils/item.js
+++ b/backend/src/utils/item.js
@@ -2,7 +2,14 @@ const MapItem = require('../models/MapItem');
 
 async function dropMapItem(pls, name, kind, effect, uses, skill, session) {
   if (!name) return;
-  const data = { itm: name, itmk: kind, itme: effect, itms: uses, itmsk: skill, pls };
+  const data = {
+    itm: name,
+    itmk: kind,
+    itme: effect,
+    itms: String(uses),
+    itmsk: skill,
+    pls
+  };
   if (session) {
     await MapItem.create([data], { session });
   } else {
@@ -18,7 +25,7 @@ async function restoreMemoryItem(player) {
       itm: item.itm,
       itmk: item.itmk,
       itme: item.itme,
-      itms: item.itms,
+      itms: String(item.itms),
       itmsk: item.itmsk,
       pls: item.pls
     };

--- a/backend/src/utils/item.js
+++ b/backend/src/utils/item.js
@@ -10,6 +10,26 @@ async function dropMapItem(pls, name, kind, effect, uses, skill, session) {
   }
 }
 
+async function restoreMemoryItem(player) {
+  if (!player.searchmemory) return;
+  try {
+    const item = JSON.parse(player.searchmemory);
+    const data = {
+      itm: item.itm,
+      itmk: item.itmk,
+      itme: item.itme,
+      itms: item.itms,
+      itmsk: item.itmsk,
+      pls: item.pls
+    };
+    await MapItem.create(data);
+  } catch (e) {
+    console.error(e);
+  }
+  player.searchmemory = '';
+}
+
 module.exports = {
-  dropMapItem
+  dropMapItem,
+  restoreMemoryItem
 };


### PR DESCRIPTION
## Summary
- track pending map items in player `searchmemory`
- return unpicked items to the map when moving or searching again
- update pickup actions to use the stored item instead of querying the map

## Testing
- `npm test --prefix backend` *(fails: Error: no test specified)*

------
https://chatgpt.com/codex/tasks/task_e_6875eeeadf60832281c468c4bbb58301