### PR TITLE
Fix file path for game data

### DIFF
--- a/backend/src/services/gameService.js
+++ b/backend/src/services/gameService.js
@@ -33,7 +33,7 @@ let trapSchedule = null;
 
 function loadTraps(filePath) {
   if (!trapSchedule) {
-    const file = filePath || path.join(__dirname, '../../../data/maptraps.json');
+    const file = filePath || path.resolve(__dirname, '../../../data/maptraps.json');
     const traps = JSON.parse(fs.readFileSync(file));
     trapSchedule = {};
     traps.forEach(t => {
@@ -64,7 +64,7 @@ async function ensureDefaultClubs() {
   const count = await Club.countDocuments();
   if (count === 0) {
     try {
-      const file = path.join(__dirname, '../../../data/clubs.json');
+      const file = path.resolve(__dirname, '../../../data/clubs.json');
       const clubs = JSON.parse(fs.readFileSync(file));
       if (clubs && clubs.length) {
         await Club.insertMany(clubs);
@@ -111,7 +111,7 @@ async function startGame(gametype = 0) {
     19: 'instance9_rush'
   };
 
-  const baseDir = path.join(__dirname, '../../../data');
+  const baseDir = path.resolve(__dirname, '../../../data');
   const instanceDir = instMap[gametype] ? path.join(baseDir, 'instances', instMap[gametype]) : baseDir;
 
   try {

--- a/backend/src/services/player/entry.js
+++ b/backend/src/services/player/entry.js
@@ -6,7 +6,7 @@ const { checkDangerAreas } = require('../gameService');
 const fs = require('fs');
 const path = require('path');
 
-const dataDir = path.join(__dirname, '../../../data');
+const dataDir = path.resolve(__dirname, '../../../../data');
 const startItems = JSON.parse(fs.readFileSync(path.join(dataDir, 'start_items.json')));
 const startWeapons = JSON.parse(fs.readFileSync(path.join(dataDir, 'start_weapons.json')));
 


### PR DESCRIPTION
## Summary
- resolve absolute path to `data` directory in player entry
- fix path resolution for data files in game service

## Testing
- `npm test` *(fails: Error: no test specified)*
- `npm run dev` *(fails: nodemon permission denied)*
- `node src/app.js` *(fails: Cannot find module 'bcrypt')*

------
https://chatgpt.com/codex/tasks/task_e_687727fc4890832291413fb2d9567677